### PR TITLE
Interpolator now uses the transfer matrix also in parallel

### DIFF
--- a/cashocs/_utils/linalg.py
+++ b/cashocs/_utils/linalg.py
@@ -376,14 +376,11 @@ class Interpolator:
             The result of the interpolation.
 
         """
-        if fenics.MPI.comm_world.size <= 1:
-            v = fenics.Function(self.target_space)
-            x = fenics.as_backend_type(u.vector()).vec()
-            _, temp = self.transfer_matrix.getVecs()
-            self.transfer_matrix.mult(x, temp)
-            v.vector().vec().aypx(0.0, temp)
-            v.vector().apply("")
-        else:
-            v = fenics.interpolate(u, self.target_space)
+        v = fenics.Function(self.target_space)
+        x = fenics.as_backend_type(u.vector()).vec()
+        _, temp = self.transfer_matrix.getVecs()
+        self.transfer_matrix.mult(x, temp)
+        v.vector().vec().aypx(0.0, temp)
+        v.vector().apply("")
 
         return v

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,11 +158,11 @@ def test_interpolator():
     W = FunctionSpace(mesh, "CG", 2)
     X = FunctionSpace(mesh, "DG", 0)
 
-    interp_W = cashocs._utils.Interpolator(V, W)
-    interp_X = cashocs._utils.Interpolator(V, X)
+    interp_W = cashocs.Interpolator(V, W)
+    interp_X = cashocs.Interpolator(V, X)
 
-    func_V = Function(V)
-    func_V.vector().set_local(rng.rand(func_V.vector().local_size()))
+    expr = Expression("sin(2*pi*x[0])*sin(2*pi*x[1])", degree=1)
+    func_V = interpolate(expr, V)
 
     fen_W = interpolate(func_V, W)
     fen_X = interpolate(func_V, X)


### PR DESCRIPTION
There was a bug in the tests, where DoFs shared between processors had different values,
which made it impossible for the tests to succeed in parallel.

Closes #27 