### PR TITLE
Fix docker builds workflow

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update --fix-missing \
 
 RUN conda install -c conda-forge mamba \
   && mamba create -n cashocs -c conda-forge fenics=2019 meshio">=5.0.0" pytest">=7.0.0" gmsh">=4.8" coverage">=6.1.0" mpich python=3.11 \
-  && conda clean -tipsy
+  && conda clean --all --yes
 
 
 FROM test-env AS cashocs

--- a/demos/documented/optimal_control/multiple_variables/demo_multiple_variables.py
+++ b/demos/documented/optimal_control/multiple_variables/demo_multiple_variables.py
@@ -24,7 +24,11 @@
 #
 # $$
 # \begin{align}
-#     &\min\; J((y,z), (u,v)) = \frac{1}{2} \int_\Omega \left( y - y_d \right) \text{ d}x + \frac{1}{2} \int_\Omega \left( z - z_d \right) \text{ d}x + \frac{\alpha}{2} \int_\Omega u^2 \text{ d}x + \frac{\beta}{2} \int_\Omega v^2 \text{ d}x \\
+#     &\min\; J((y,z), (u,v)) =
+#     \frac{1}{2} \int_\Omega \left( y - y_d \right)^2 \text{ d}x
+#     + \frac{1}{2} \int_\Omega \left( z - z_d \right)^2 \text{ d}x
+#     + \frac{\alpha}{2} \int_\Omega u^2 \text{ d}x
+#     + \frac{\beta}{2} \int_\Omega v^2 \text{ d}x \\
 #     &\text{ subject to } \qquad
 #     \begin{alignedat}[t]{2}
 #         -\Delta y &= u \quad &&\text{ in } \Omega, \\


### PR DESCRIPTION
This PR changes cashocs Dockerfile so that conda clean --all --yes is used instead of -tipsy. The latter seems to be deprecated and causes an error.

Closes #156 