### PR TITLE
Add automatic treatmeant of fieldsplit preconditioner

### DIFF
--- a/cashocs/_constraints/solvers.py
+++ b/cashocs/_constraints/solvers.py
@@ -208,9 +208,8 @@ class AugmentedLagrangianMethod(ConstrainedSolver):
         rhs = project_term * test * measure
 
         _utils.assemble_and_solve_linear(
-            lhs, rhs, A=A_tensor, b=b_tensor, x=multiplier.vector().vec()
+            lhs, rhs, A=A_tensor, b=b_tensor, fun=multiplier
         )
-        multiplier.vector().apply("")
 
     def _update_cost_functional(self) -> None:
         """Updates the cost functional with new weights."""

--- a/cashocs/_forms/shape_regularization.py
+++ b/cashocs/_forms/shape_regularization.py
@@ -608,9 +608,8 @@ class CurvatureRegularization(ShapeRegularizationTerm):
         _utils.solve_linear_problem(
             A=self.a_curvature_matrix.mat(),
             b=self.b_curvature.vec(),
-            x=self.kappa_curvature.vector().vec(),
+            fun=self.kappa_curvature,
         )
-        self.kappa_curvature.vector().apply("")
 
     def scale(self) -> None:
         """Scales the regularization term."""

--- a/cashocs/_pde_problems/adjoint_problem.py
+++ b/cashocs/_pde_problems/adjoint_problem.py
@@ -117,10 +117,9 @@ class AdjointProblem(pde_problem.PDEProblem):
                         self.bcs_list_ad[-1 - i],
                         A=self.A_tensors[-1 - i],
                         b=self.b_tensors[-1 - i],
-                        x=self.adjoints[-1 - i].vector().vec(),
+                        fun=self.adjoints[-1 - i],
                         ksp_options=self.db.parameter_db.adjoint_ksp_options[-1 - i],
                     )
-                    self.adjoints[-1 - i].vector().apply("")
 
             else:
                 nonlinear_solvers.picard_iteration(

--- a/cashocs/_pde_problems/control_gradient_problem.py
+++ b/cashocs/_pde_problems/control_gradient_problem.py
@@ -109,10 +109,9 @@ class ControlGradientProblem(pde_problem.PDEProblem):
                 _utils.solve_linear_problem(
                     A=self.form_handler.riesz_projection_matrices[i],
                     b=self.b_tensors[i].vec(),
-                    x=self.db.function_db.gradient[i].vector().vec(),
+                    fun=self.db.function_db.gradient[i],
                     ksp_options=self.riesz_ksp_options[i],
                 )
-                self.db.function_db.gradient[i].vector().apply("")
 
             self.has_solution = True
 

--- a/cashocs/_pde_problems/hessian_problems.py
+++ b/cashocs/_pde_problems/hessian_problems.py
@@ -172,10 +172,9 @@ class HessianProblem:
                     self.form_handler.hessian_form_handler.sensitivity_eqs_lhs[i],
                     self.form_handler.hessian_form_handler.sensitivity_eqs_rhs[i],
                     self.bcs_list_ad[i],
-                    x=self.db.function_db.states_prime[i].vector().vec(),
+                    fun=self.db.function_db.states_prime[i],
                     ksp_options=self.db.parameter_db.state_ksp_options[i],
                 )
-                self.db.function_db.states_prime[i].vector().apply("")
 
             for i in range(self.state_dim):
                 _utils.assemble_and_solve_linear(
@@ -184,10 +183,9 @@ class HessianProblem:
                     ],
                     self.form_handler.hessian_form_handler.w_1[-1 - i],
                     self.bcs_list_ad[-1 - i],
-                    x=self.db.function_db.adjoints_prime[-1 - i].vector().vec(),
+                    fun=self.db.function_db.adjoints_prime[-1 - i],
                     ksp_options=self.db.parameter_db.adjoint_ksp_options[-1 - i],
                 )
-                self.db.function_db.adjoints_prime[-1 - i].vector().apply("")
 
         else:
             nonlinear_solvers.picard_iteration(
@@ -234,10 +232,9 @@ class HessianProblem:
             _utils.solve_linear_problem(
                 A=self.form_handler.riesz_projection_matrices[i],
                 b=b,
-                x=out[i].vector().vec(),
+                fun=out[i],
                 ksp_options=self.riesz_ksp_options[i],
             )
-            out[i].vector().apply("")
 
         self.no_sensitivity_solves += 2
 

--- a/cashocs/_pde_problems/shape_gradient_problem.py
+++ b/cashocs/_pde_problems/shape_gradient_problem.py
@@ -152,10 +152,9 @@ class ShapeGradientProblem(pde_problem.PDEProblem):
                 _utils.solve_linear_problem(
                     A=self.form_handler.scalar_product_matrix,
                     b=self.form_handler.fe_shape_derivative_vector.vec(),
-                    x=self.db.function_db.gradient[0].vector().vec(),
+                    fun=self.db.function_db.gradient[0],
                     ksp_options=self.ksp_options,
                 )
-                self.db.function_db.gradient[0].vector().apply("")
 
                 self.has_solution = True
 

--- a/cashocs/_pde_problems/state_problem.py
+++ b/cashocs/_pde_problems/state_problem.py
@@ -126,10 +126,9 @@ class StateProblem(pde_problem.PDEProblem):
                             self.bcs_list[i],
                             A=self.A_tensors[i],
                             b=self.b_tensors[i],
-                            x=self.states[i].vector().vec(),
+                            fun=self.states[i],
                             ksp_options=self.db.parameter_db.state_ksp_options[i],
                         )
-                        self.states[i].vector().apply("")
 
                 else:
                     for i in range(self.db.parameter_db.state_dim):

--- a/cashocs/geometry/boundary_distance.py
+++ b/cashocs/geometry/boundary_distance.py
@@ -95,10 +95,7 @@ def compute_boundary_distance(
     lhs = fenics.dot(fenics.grad(u), fenics.grad(v)) * dx
     rhs = fenics.Constant(1.0) * v * dx
 
-    _utils.assemble_and_solve_linear(
-        lhs, rhs, bcs, x=u_curr.vector().vec(), ksp_options=ksp_options
-    )
-    u_curr.vector().apply("")
+    _utils.assemble_and_solve_linear(lhs, rhs, bcs, fun=u_curr, ksp_options=ksp_options)
 
     rhs = fenics.dot(fenics.grad(u_prev) / norm_u_prev, fenics.grad(v)) * dx
 
@@ -117,9 +114,8 @@ def compute_boundary_distance(
         u_prev.vector().vec().aypx(0.0, u_curr.vector().vec())
         u_prev.vector().apply("")
         _utils.assemble_and_solve_linear(
-            lhs, rhs, bcs, x=u_curr.vector().vec(), ksp_options=ksp_options
+            lhs, rhs, bcs, fun=u_curr, ksp_options=ksp_options
         )
-        u_curr.vector().apply("")
         res = np.sqrt(fenics.assemble(residual_form))
 
         if res <= res_0 * tol:

--- a/cashocs/geometry/quality.py
+++ b/cashocs/geometry/quality.py
@@ -414,10 +414,7 @@ class ConditionNumberCalculator(MeshQualityCalculator):
 
         cond = fenics.Function(function_space_dg0)
 
-        _utils.assemble_and_solve_linear(
-            lhs, rhs, x=cond.vector().vec(), ksp_options=options
-        )
-        cond.vector().apply("")
+        _utils.assemble_and_solve_linear(lhs, rhs, fun=cond, ksp_options=options)
         cond.vector().vec().reciprocal()
         cond.vector().apply("")
         cond.vector().vec().scale(np.sqrt(mesh.geometric_dimension()))

--- a/cashocs/nonlinear_solvers/newton_solver.py
+++ b/cashocs/nonlinear_solvers/newton_solver.py
@@ -259,12 +259,11 @@ class _NewtonSolver:
             _utils.solve_linear_problem(
                 A=self.A_matrix,
                 b=self.b,
-                x=self.du.vector().vec(),
+                fun=self.du,
                 ksp_options=self.ksp_options,
                 rtol=self.eta,
                 atol=self.atol / 10.0,
             )
-            self.du.vector().apply("")
 
             if self.is_linear:
                 self.u.vector().vec().axpy(1.0, self.du.vector().vec())
@@ -364,12 +363,11 @@ class _NewtonSolver:
                 _utils.solve_linear_problem(
                     A=self.A_matrix,
                     b=self.b,
-                    x=self.ddu.vector().vec(),
+                    fun=self.ddu,
                     ksp_options=self.ksp_options,
                     rtol=self.eta,
                     atol=self.atol / 10.0,
                 )
-                self.ddu.vector().apply("")
 
                 if (
                     self.ddu.vector().norm(self.norm_type)


### PR DESCRIPTION
This ensures that the state matrix for a mixed problem is split correctly (for saddle-point problems) when a fieldsplit preconditioner is used.