### PR TITLE
Adds a linear solver interface and preconditioner forms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,10 @@ of the maintenance releases, please take a look at
 
 * The options for defining parameters which are to be supplied to PETSc KSP objects have changed their datatype: They are now given by (lists of) dictionaries instead of nested lists. For options without a value in the command line (e.g. the option :bash:`-ksp_view`) have a value of :python:`None` in the dictionary (so :python:`'ksp_view': None` can be used inside the dictionary to supply the aforementioned option).
 
+* cashocs now includes a :py:func:`cashocs.linear_solve` that can be used to solve linear problems.
+
+* Optimization problems, constrained problems, space mapping problems, and linear and nonlinear solvers now include the keyword argument :python:`preconditioner_forms`, which is a list of UFL forms used to define the preconditioner matrices for solving the respective PDEs.
+
 * Added different mesh conversion modes for :py:func:`cashocs.convert`, which are :python:`"physical"`, :python:`"geometrical"`, and :python:`"none"`. These are used to either use the physical or geometrical entities of Gmsh for the definition of the boundaries and subdomains (or neither of these).
 
 * Changed configuration file parameters

--- a/cashocs/__init__.py
+++ b/cashocs/__init__.py
@@ -54,6 +54,7 @@ from cashocs.geometry import regular_mesh
 from cashocs.io import convert
 from cashocs.io import import_mesh
 from cashocs.io import load_config
+from cashocs.nonlinear_solvers import linear_solve
 from cashocs.nonlinear_solvers import newton_solve
 from cashocs.nonlinear_solvers import picard_iteration
 
@@ -115,4 +116,5 @@ __all__ = [
     "interval_mesh",
     "convert",
     "space_mapping",
+    "linear_solve",
 ]

--- a/cashocs/_constraints/constrained_problems.py
+++ b/cashocs/_constraints/constrained_problems.py
@@ -60,6 +60,7 @@ class ConstrainedOptimizationProblem(abc.ABC):
         adjoint_ksp_options: Optional[
             Union[_typing.KspOption, List[_typing.KspOption]]
         ] = None,
+        preconditioner_forms: Optional[List[ufl.Form]] = None,
     ) -> None:
         """Initializes self.
 
@@ -93,6 +94,9 @@ class ConstrainedOptimizationProblem(abc.ABC):
                 for PETSc, used to solve the adjoint systems. If this is ``None``, then
                 the same options as for the state systems are used (default is
                 ``None``).
+            preconditioner_forms: The list of forms for the preconditioner. The default
+                is `None`, so that the preconditioner matrix is the same as the system
+                matrix.
 
         """
         self.state_forms = state_forms
@@ -109,6 +113,7 @@ class ConstrainedOptimizationProblem(abc.ABC):
         self.initial_guess = initial_guess
         self.ksp_options = ksp_options
         self.adjoint_ksp_options = adjoint_ksp_options
+        self.preconditioner_forms = preconditioner_forms
 
         self.current_function_value = 0.0
 
@@ -283,6 +288,7 @@ class ConstrainedOptimalControlProblem(ConstrainedOptimizationProblem):
                 List[List[fenics.DirichletBC]],
             ]
         ] = None,
+        preconditioner_forms: Optional[List[ufl.Form]] = None,
     ) -> None:
         r"""Initializes self.
 
@@ -327,6 +333,9 @@ class ConstrainedOptimalControlProblem(ConstrainedOptimizationProblem):
                 ``None``).
             control_bcs_list: A list of boundary conditions for the control variables.
                 This is passed analogously to ``bcs_list``. Default is ``None``.
+            preconditioner_forms: The list of forms for the preconditioner. The default
+                is `None`, so that the preconditioner matrix is the same as the system
+                matrix.
 
         """
         super().__init__(
@@ -340,6 +349,7 @@ class ConstrainedOptimalControlProblem(ConstrainedOptimizationProblem):
             initial_guess=initial_guess,
             ksp_options=ksp_options,
             adjoint_ksp_options=adjoint_ksp_options,
+            preconditioner_forms=preconditioner_forms,
         )
 
         self.controls = controls
@@ -381,6 +391,7 @@ class ConstrainedOptimalControlProblem(ConstrainedOptimizationProblem):
             ksp_options=self.ksp_options,
             adjoint_ksp_options=self.adjoint_ksp_options,
             control_bcs_list=self.control_bcs_list,
+            preconditioner_forms=self.preconditioner_forms,
         )
 
         optimal_control_problem.inject_pre_post_callback(
@@ -443,6 +454,7 @@ class ConstrainedShapeOptimizationProblem(ConstrainedOptimizationProblem):
         adjoint_ksp_options: Optional[
             Union[_typing.KspOption, List[_typing.KspOption]]
         ] = None,
+        preconditioner_forms: Optional[List[ufl.Form]] = None,
     ) -> None:
         """Initializes self.
 
@@ -484,6 +496,9 @@ class ConstrainedShapeOptimizationProblem(ConstrainedOptimizationProblem):
                 for PETSc, used to solve the adjoint systems. If this is ``None``, then
                 the same options as for the state systems are used (default is
                 ``None``).
+            preconditioner_forms: The list of forms for the preconditioner. The default
+                is `None`, so that the preconditioner matrix is the same as the system
+                matrix.
 
         """
         super().__init__(
@@ -497,6 +512,7 @@ class ConstrainedShapeOptimizationProblem(ConstrainedOptimizationProblem):
             initial_guess=initial_guess,
             ksp_options=ksp_options,
             adjoint_ksp_options=adjoint_ksp_options,
+            preconditioner_forms=preconditioner_forms,
         )
 
         self.boundaries = boundaries
@@ -534,6 +550,7 @@ class ConstrainedShapeOptimizationProblem(ConstrainedOptimizationProblem):
             initial_guess=self.initial_guess,
             ksp_options=self.ksp_options,
             adjoint_ksp_options=self.adjoint_ksp_options,
+            preconditioner_forms=self.preconditioner_forms,
         )
         shape_optimization_problem.inject_pre_post_callback(
             self._pre_callback, self._post_callback

--- a/cashocs/_database/database.py
+++ b/cashocs/_database/database.py
@@ -49,6 +49,7 @@ class Database:
         cost_functional_list: List[_typing.CostFunctional],
         state_forms: List[ufl.Form],
         bcs_list: List[List[fenics.DirichletBC]],
+        preconditioner_forms: List[ufl.Form],
     ) -> None:
         """Initialize the database.
 
@@ -61,6 +62,9 @@ class Database:
             cost_functional_list: The list of cost functionals.
             state_forms: The list of state forms.
             bcs_list: The list of Dirichlet boundary conditions for the state system.
+            preconditioner_forms: The list of forms for the preconditioner. The default
+                is `None`, so that the preconditioner matrix is the same as the system
+                matrix.
 
         """
         self.config = config
@@ -75,5 +79,5 @@ class Database:
         )
         self.geometry_db = geometry_database.GeometryDatabase(self.function_db)
         self.form_db = form_database.FormDatabase(
-            cost_functional_list, state_forms, bcs_list
+            cost_functional_list, state_forms, bcs_list, preconditioner_forms
         )

--- a/cashocs/_database/form_database.py
+++ b/cashocs/_database/form_database.py
@@ -38,6 +38,7 @@ class FormDatabase:
         cost_functional_list: List[_typing.CostFunctional],
         state_forms: List[ufl.Form],
         bcs_list: List[List[fenics.DirichletBC]],
+        preconditioner_forms: List[ufl.Form],
     ):
         """Initializes the form database.
 
@@ -45,11 +46,15 @@ class FormDatabase:
             cost_functional_list: The list of cost functionals.
             state_forms: The list of state forms.
             bcs_list: The list of boundary conditions for the state system.
+            preconditioner_forms: The list of forms for the preconditioner. The default
+                is `None`, so that the preconditioner matrix is the same as the system
+                matrix.
 
         """
         self.cost_functional_list = cost_functional_list
         self.state_forms = state_forms
         self.bcs_list = bcs_list
+        self.preconditioner_forms = preconditioner_forms
 
         self.lagrangian = cost_functional.Lagrangian(
             self.cost_functional_list, self.state_forms

--- a/cashocs/_optimization/optimal_control/optimal_control_problem.py
+++ b/cashocs/_optimization/optimal_control/optimal_control_problem.py
@@ -83,6 +83,7 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
                 fenics.DirichletBC,
             ]
         ] = None,
+        preconditioner_forms: Optional[Union[List[ufl.Form], ufl.Form]] = None,
     ) -> None:
         r"""Initializes self.
 
@@ -131,6 +132,9 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
                 `None`.
             control_bcs_list: A list of boundary conditions for the control variables.
                 This is passed analogously to ``bcs_list``. Default is ``None``.
+            preconditioner_forms: The list of forms for the preconditioner. The default
+                is `None`, so that the preconditioner matrix is the same as the system
+                matrix.
 
         Examples:
             Examples how to use this class can be found in the :ref:`tutorial
@@ -143,11 +147,12 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
             cost_functional_form,
             states,
             adjoints,
-            config,
-            initial_guess,
-            ksp_options,
-            adjoint_ksp_options,
-            desired_weights,
+            config=config,
+            initial_guess=initial_guess,
+            ksp_options=ksp_options,
+            adjoint_ksp_options=adjoint_ksp_options,
+            desired_weights=desired_weights,
+            preconditioner_forms=preconditioner_forms,
         )
 
         self.db.function_db.controls = _utils.enlist(controls)

--- a/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
+++ b/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
@@ -90,6 +90,7 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
         desired_weights: Optional[List[float]] = None,
         temp_dict: Optional[Dict] = None,
         initial_function_values: Optional[List[float]] = None,
+        preconditioner_forms: Optional[Union[List[ufl.Form], ufl.Form]] = None,
     ) -> None:
         """Initializes self.
 
@@ -141,6 +142,9 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
             initial_function_values: This is a privatve parameter of the class, required
                 for remeshing. This parameter must not be set by the user and should be
                 ignored. Using this parameter may result in unintended side effects.
+            preconditioner_forms: The list of forms for the preconditioner. The default
+                is `None`, so that the preconditioner matrix is the same as the system
+                matrix.
 
         """
         super().__init__(
@@ -149,13 +153,14 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
             cost_functional_form,
             states,
             adjoints,
-            config,
-            initial_guess,
-            ksp_options,
-            adjoint_ksp_options,
-            desired_weights,
-            temp_dict,
-            initial_function_values,
+            config=config,
+            initial_guess=initial_guess,
+            ksp_options=ksp_options,
+            adjoint_ksp_options=adjoint_ksp_options,
+            desired_weights=desired_weights,
+            temp_dict=temp_dict,
+            initial_function_values=initial_function_values,
+            preconditioner_forms=preconditioner_forms,
         )
 
         if shape_scalar_product is None:

--- a/cashocs/_pde_problems/adjoint_problem.py
+++ b/cashocs/_pde_problems/adjoint_problem.py
@@ -123,6 +123,9 @@ class AdjointProblem(pde_problem.PDEProblem):
                         fun=self.adjoints[-1 - i],
                         ksp_options=self.db.parameter_db.adjoint_ksp_options[-1 - i],
                         comm=self.db.geometry_db.mpi_comm,
+                        preconditioner_form=self.db.form_db.preconditioner_forms[
+                            -1 - i
+                        ],
                     )
 
             else:
@@ -142,6 +145,7 @@ class AdjointProblem(pde_problem.PDEProblem):
                     A_tensors=self.A_tensors[::-1],
                     b_tensors=self.b_tensors[::-1],
                     inner_is_linear=True,
+                    preconditioner_forms=self.db.form_db.preconditioner_forms[::-1],
                 )
 
             self.has_solution = True

--- a/cashocs/_pde_problems/hessian_problems.py
+++ b/cashocs/_pde_problems/hessian_problems.py
@@ -174,6 +174,7 @@ class HessianProblem:
                     fun=self.db.function_db.states_prime[i],
                     ksp_options=self.db.parameter_db.state_ksp_options[i],
                     comm=self.db.geometry_db.mpi_comm,
+                    preconditioner_form=self.db.form_db.preconditioner_forms[i],
                 )
 
             for i in range(self.state_dim):
@@ -186,6 +187,7 @@ class HessianProblem:
                     fun=self.db.function_db.adjoints_prime[-1 - i],
                     ksp_options=self.db.parameter_db.adjoint_ksp_options[-1 - i],
                     comm=self.db.geometry_db.mpi_comm,
+                    preconditioner_form=self.db.form_db.preconditioner_forms[-1 - i],
                 )
 
         else:
@@ -205,6 +207,7 @@ class HessianProblem:
                 A_tensors=self.state_A_tensors,
                 b_tensors=self.state_b_tensors,
                 inner_is_linear=True,
+                preconditioner_forms=self.db.form_db.preconditioner_forms,
             )
 
             nonlinear_solvers.picard_iteration(
@@ -223,6 +226,7 @@ class HessianProblem:
                 A_tensors=self.adjoint_A_tensors,
                 b_tensors=self.adjoint_b_tensors,
                 inner_is_linear=True,
+                preconditioner_forms=self.db.form_db.preconditioner_forms,
             )
 
         for i in range(len(out)):

--- a/cashocs/_pde_problems/state_problem.py
+++ b/cashocs/_pde_problems/state_problem.py
@@ -128,6 +128,7 @@ class StateProblem(pde_problem.PDEProblem):
                             fun=self.states[i],
                             ksp_options=self.db.parameter_db.state_ksp_options[i],
                             comm=self.db.geometry_db.mpi_comm,
+                            preconditioner_form=self.db.form_db.preconditioner_forms[i],
                         )
 
                 else:
@@ -147,6 +148,7 @@ class StateProblem(pde_problem.PDEProblem):
                             ksp_options=self.db.parameter_db.state_ksp_options[i],
                             A_tensor=self.A_tensors[i],
                             b_tensor=self.b_tensors[i],
+                            preconditioner_form=self.db.form_db.preconditioner_forms[i],
                         )
 
             else:
@@ -166,6 +168,7 @@ class StateProblem(pde_problem.PDEProblem):
                     A_tensors=self.A_tensors,
                     b_tensors=self.b_tensors,
                     inner_is_linear=self.config.getboolean("StateSystem", "is_linear"),
+                    preconditioner_forms=self.db.form_db.preconditioner_forms,
                 )
 
             self.has_solution = True

--- a/cashocs/nonlinear_solvers/__init__.py
+++ b/cashocs/nonlinear_solvers/__init__.py
@@ -21,7 +21,8 @@ This module has custom solvers for nonlinear PDEs, including a damped Newton met
 a Picard iteration for coupled problems.
 """
 
+from cashocs.nonlinear_solvers.linear_solver import linear_solve
 from cashocs.nonlinear_solvers.newton_solver import newton_solve
 from cashocs.nonlinear_solvers.picard_solver import picard_iteration
 
-__all__ = ["newton_solve", "picard_iteration"]
+__all__ = ["newton_solve", "picard_iteration", "linear_solve"]

--- a/cashocs/nonlinear_solvers/linear_solver.py
+++ b/cashocs/nonlinear_solvers/linear_solver.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2020-2023 Sebastian Blauth
+#
+# This file is part of cashocs.
+#
+# cashocs is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cashocs is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cashocs.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Linear solver for linear PDEs."""
+
+from __future__ import annotations
+
+from typing import List, Optional, TYPE_CHECKING, Union
+
+import fenics
+import numpy as np
+import ufl
+
+from cashocs import _utils
+
+if TYPE_CHECKING:
+    from cashocs import _typing
+
+
+def linear_solve(
+    linear_form: ufl.Form,
+    u: fenics.Function,
+    bcs: Union[fenics.DirichletBC, List[fenics.DirichletBC]],
+    ksp_options: Optional[_typing.KspOption] = None,
+    preconditioner_form: ufl.Form = None,
+    A_tensor: Optional[fenics.PETScMatrix] = None,  # pylint: disable=invalid-name
+    b_tensor: Optional[fenics.PETScVector] = None,
+) -> fenics.Function:
+    """Solves a linear problem.
+
+    Args:
+        linear_form: The linear variational form of the problem, i.e., linear_form == 0
+        u: The function to be solved for
+        bcs: The boundary conditions for the problem
+        ksp_options: The options for the PETSc KSP solver, optional. Default is `None`,
+            where the linear solver MUMPS is used
+        A_tensor: A fenics.PETScMatrix for storing the left-hand side of the linear
+            sub-problem.
+        b_tensor: A fenics.PETScVector for storing the right-hand side of the linear
+            sub-problem.
+
+    Returns:
+        The computed solution, this overwrites the input function `u`.
+
+    """
+    lhs_form = _utils.bilinear_boundary_form_modification(
+        [fenics.derivative(linear_form, u)]
+    )[0]
+    rhs_form = -ufl.replace(linear_form, {u: fenics.Constant(np.zeros(u.ufl_shape))})
+
+    assembler = fenics.SystemAssembler(lhs_form, rhs_form, bcs)
+    assembler.keep_diagonal = True
+
+    comm = u.function_space().mesh().mpi_comm()
+    A_fenics = A_tensor or fenics.PETScMatrix(comm)  # pylint: disable=invalid-name
+    b_fenics = b_tensor or fenics.PETScVector(comm)
+
+    assembler.assemble(A_fenics)
+    A_fenics.ident_zeros()
+    A_matrix = fenics.as_backend_type(A_fenics).mat()  # pylint: disable=invalid-name
+
+    assembler.assemble(b_fenics)
+    b = fenics.as_backend_type(b_fenics).vec()
+
+    if preconditioner_form is not None:
+        if len(preconditioner_form.arguments()) == 1:
+            preconditioner_form = fenics.derivative(preconditioner_form, u)
+
+        P_fenics = fenics.PETScMatrix(comm)  # pylint: disable=invalid-name
+        assembler_p = fenics.SystemAssembler(preconditioner_form, rhs_form, bcs)
+        assembler_p.keep_diagonal = True
+
+        assembler_p.assemble(P_fenics)
+        P_matrix = fenics.as_backend_type(  # pylint: disable=invalid-name
+            P_fenics
+        ).mat()
+    else:
+        P_matrix = None  # pylint: disable=invalid-name
+
+    _utils.solve_linear_problem(
+        A=A_matrix, b=b, fun=u, ksp_options=ksp_options, comm=comm, P=P_matrix
+    )
+
+    return u

--- a/cashocs/nonlinear_solvers/picard_solver.py
+++ b/cashocs/nonlinear_solvers/picard_solver.py
@@ -93,6 +93,7 @@ def picard_iteration(
     A_tensors: Optional[List[fenics.PETScMatrix]] = None,
     b_tensors: Optional[List[fenics.PETScVector]] = None,
     inner_is_linear: bool = False,
+    preconditioner_forms: Optional[Union[List[ufl.Form], ufl.Form]] = None,
 ) -> None:
     """Solves a system of coupled PDEs via a Picard iteration.
 
@@ -120,6 +121,9 @@ def picard_iteration(
             equations.
         inner_is_linear: Boolean flag, if this is ``True``, all problems are actually
             linear ones, and only a linear solver is used.
+        preconditioner_forms: The list of forms for the preconditioner. The default
+                is `None`, so that the preconditioner matrix is the same as the system
+                matrix.
 
     """
     is_printing = verbose and fenics.MPI.rank(fenics.MPI.comm_world) == 0
@@ -127,6 +131,7 @@ def picard_iteration(
     u_list = _utils.enlist(u_list)
     bcs_list = _utils.check_and_enlist_bcs(bcs_list)
     bcs_list_hom = _create_homogenized_bcs(bcs_list)
+    preconditioner_form_list = _utils.enlist(preconditioner_forms)
 
     comm = u_list[0].function_space().mesh().mpi_comm()
 
@@ -182,6 +187,7 @@ def picard_iteration(
                 A_tensor=A_tensor,
                 b_tensor=b_tensor,
                 is_linear=inner_is_linear,
+                preconditioner_form=preconditioner_form_list[j],
             )
 
     if is_printing:

--- a/cashocs/space_mapping/optimal_control.py
+++ b/cashocs/space_mapping/optimal_control.py
@@ -88,6 +88,7 @@ class CoarseModel:
             Union[_typing.KspOption, List[_typing.KspOption]]
         ] = None,
         desired_weights: Optional[List[float]] = None,
+        preconditioner_forms: Optional[List[ufl.Form]] = None,
     ) -> None:
         """Initializes self.
 
@@ -109,7 +110,10 @@ class CoarseModel:
             initial_guess: The initial guess for solving a nonlinear state equation
             ksp_options: The list of PETSc options for the state equations
             adjoint_ksp_options: The list of PETSc options for the adjoint equations
-            desired_weights: The desired weights for the cost functional
+            desired_weights: The desired weights for the cost functional.
+            preconditioner_forms: The list of forms for the preconditioner. The default
+                is `None`, so that the preconditioner matrix is the same as the system
+                matrix.
 
         """
         self.state_forms = state_forms
@@ -125,6 +129,7 @@ class CoarseModel:
         self.ksp_options = ksp_options
         self.adjoint_ksp_options = adjoint_ksp_options
         self.desired_weights = desired_weights
+        self.preconditioner_forms = preconditioner_forms
 
         self._pre_callback: Optional[Callable] = None
         self._post_callback: Optional[Callable] = None
@@ -143,6 +148,7 @@ class CoarseModel:
             ksp_options=self.ksp_options,
             adjoint_ksp_options=self.adjoint_ksp_options,
             desired_weights=self.desired_weights,
+            preconditioner_forms=self.preconditioner_forms,
         )
 
     def optimize(self) -> None:
@@ -239,6 +245,7 @@ class ParameterExtraction:
         self.adjoint_ksp_options = (
             coarse_model.optimal_control_problem.adjoint_ksp_options
         )
+        self.preconditioner_forms = coarse_model.preconditioner_forms
         self.optimal_control_problem: Optional[ocp.OptimalControlProblem] = None
 
     def _solve(self, initial_guesses: Optional[List[fenics.Function]] = None) -> None:
@@ -277,6 +284,7 @@ class ParameterExtraction:
             ksp_options=self.ksp_options,
             adjoint_ksp_options=self.adjoint_ksp_options,
             desired_weights=self.desired_weights,
+            preconditioner_forms=self.preconditioner_forms,
         )
 
         self.optimal_control_problem.inject_pre_post_callback(

--- a/cashocs/space_mapping/shape_optimization.py
+++ b/cashocs/space_mapping/shape_optimization.py
@@ -97,6 +97,7 @@ class CoarseModel:
             Union[_typing.KspOption, List[_typing.KspOption]]
         ] = None,
         desired_weights: Optional[List[float]] = None,
+        preconditioner_forms: Optional[List[ufl.Form]] = None,
     ):
         """Initializes self.
 
@@ -118,6 +119,9 @@ class CoarseModel:
             ksp_options: The list of PETSc options for the state equations
             adjoint_ksp_options: The list of PETSc options for the adjoint equations
             desired_weights: The desired weights for the cost functional
+            preconditioner_forms: The list of forms for the preconditioner. The default
+                is `None`, so that the preconditioner matrix is the same as the system
+                matrix.
 
         """
         self.state_forms = state_forms
@@ -132,6 +136,7 @@ class CoarseModel:
         self.ksp_options = ksp_options
         self.adjoint_ksp_options = adjoint_ksp_options
         self.desired_weights = desired_weights
+        self.preconditioner_forms = preconditioner_forms
 
         self._pre_callback: Optional[Callable] = None
         self._post_callback: Optional[Callable] = None
@@ -152,6 +157,7 @@ class CoarseModel:
             ksp_options=self.ksp_options,
             adjoint_ksp_options=self.adjoint_ksp_options,
             desired_weights=self.desired_weights,
+            preconditioner_forms=self.preconditioner_forms,
         )
 
         self.coordinates_optimal = self.mesh.coordinates().copy()
@@ -241,6 +247,7 @@ class ParameterExtraction:
         self.adjoint_ksp_options = (
             coarse_model.shape_optimization_problem.adjoint_ksp_options
         )
+        self.preconditioner_forms = coarse_model.preconditioner_forms
 
         self.coordinates_initial = coarse_model.coordinates_initial
 
@@ -279,6 +286,7 @@ class ParameterExtraction:
             ksp_options=self.ksp_options,
             adjoint_ksp_options=self.adjoint_ksp_options,
             desired_weights=self.desired_weights,
+            preconditioner_forms=self.preconditioner_forms,
         )
         if self.shape_optimization_problem is not None:
             self.shape_optimization_problem.inject_pre_post_callback(


### PR DESCRIPTION
This PR adds two thing: 
First is a function `cashocs.linear_solve` which can be used to solve linear PDEs more easily (compared to using `cashocs.newton_solve(..., is_linear=True)`.
Second is the keyword argument `preconditioner_forms`, which can be used to specify the corresponding weak forms for assembling the preconditioner matrices.

This PR closes #183 and also closes #168