### PR TITLE
Fixes the failing CI pipelines

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update --fix-missing \
   && rm -rf /var/lib/apt/lists/*
 
 RUN conda install -c conda-forge mamba \
-  && mamba create -n cashocs -c conda-forge fenics=2019 meshio">=5.0.0" pytest">=7.0.0" gmsh">=4.8" coverage">=6.1.0" mpich python=3.11 \
+  && mamba create -n cashocs -c conda-forge fenics=2019 meshio">=5.0.0" pytest">=7.0.0" gmsh">=4.8" "occt<=7.7.0" coverage">=6.1.0" mpich python=3.11 \
   && conda clean --all --yes
 
 

--- a/.github/workflows/test_demos.yml
+++ b/.github/workflows/test_demos.yml
@@ -28,6 +28,7 @@ jobs:
           meshio">=5.0.0"
           pytest">=7.0.0"
           gmsh">=4.8"
+          occt"<=7.7.0"
           matplotlib
           python=3.11
 
@@ -65,6 +66,7 @@ jobs:
           meshio">=5.0.0"
           pytest">=7.0.0"
           gmsh">=4.8"
+          occt"<=7.7.0"
           mpich
           matplotlib
           python=3.11

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -32,6 +32,7 @@ jobs:
           meshio">=5.0.0"
           pytest">=7.0.0"
           gmsh">=4.8"
+          occt"<=7.7.0"
 
     - name: Install package
       run: |

--- a/.github/workflows/tests_parallel.yml
+++ b/.github/workflows/tests_parallel.yml
@@ -35,6 +35,7 @@ jobs:
           meshio">=5.0.0"
           pytest">=7.0.0"
           gmsh">=4.8"
+          occt"<=7.7.0"
           ${{ matrix.mpi }}
           python=${{ matrix.python-version }}
 

--- a/.github/workflows/tests_serial.yml
+++ b/.github/workflows/tests_serial.yml
@@ -32,6 +32,7 @@ jobs:
           meshio">=5.0.0"
           pytest">=7.0.0"
           gmsh">=4.8"
+          occt"<=7.7.0"
           python=${{ matrix.python-version }}
 
     - name: Install package


### PR DESCRIPTION
The CI pipelines failed after using occt v7.7.1, this PR pins occt<=7.7.0, so that the issue does not appear.