### PR TITLE
Change the default interpolation type for the topological derivative to volume

### DIFF
--- a/cashocs/io/config.py
+++ b/cashocs/io/config.py
@@ -636,7 +636,7 @@ angle_change = inf
 
 [TopologyOptimization]
 angle_tol = 1.0
-interpolation_scheme = angle
+interpolation_scheme = volume
 normalize_topological_derivative = False
 re_normalize_levelset = False
 topological_derivative_is_identical = False


### PR DESCRIPTION
This yields the same results as angle for uniform meshes. But this approach also works in parallel currently.
See #208 