### PR TITLE
Clear PETSc's options correctly.

### DIFF
--- a/cashocs/_utils/linalg.py
+++ b/cashocs/_utils/linalg.py
@@ -189,6 +189,7 @@ def setup_petsc_options(
             from PETSc.
 
     """
+    fenics.PETScOptions.clear()
     opts = PETSc.Options()
 
     for i in range(len(ksps)):


### PR DESCRIPTION
Closes #230 

This PR adds a call to fenics.PETScOptions.clear, which correctly clears the "cache" of the PETSc Options.