### PR TITLE
Add configuration file parameter [LineSearch][fail_if_not_converged]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,12 @@ of the maintenance releases, please take a look at
 2.1.0 (in development)
 ----------------------
 
+* New configuration file parameters:
+
+  * Section LineSearch
+
+    * :ini:`fail_if_not_converged` determines, whether the line search is cancelled once the state system cannot be solved or if a new iterate is tried instead.
+
 
 
 2.0.0 (May 16, 2023)

--- a/cashocs/io/config.py
+++ b/cashocs/io/config.py
@@ -224,6 +224,9 @@ class Config(ConfigParser):
                     "attributes": ["less_than_one", "positive"],
                     "larger_than": ("LineSearch", "factor_low"),
                 },
+                "fail_if_not_converged": {
+                    "type": "bool",
+                },
             },
             "AlgoLBFGS": {
                 "bfgs_memory_size": {
@@ -560,6 +563,7 @@ safeguard_stepsize = True
 polynomial_model = cubic
 factor_high = 0.5
 factor_low = 0.1
+fail_if_not_converged = False
 
 [ShapeGradient]
 lambda_lame = 0.0

--- a/docs/source/user/demos/optimal_control/doc_config.rst
+++ b/docs/source/user/demos/optimal_control/doc_config.rst
@@ -337,6 +337,14 @@ For the polynomial models, we also have a safeguarding procedure, which ensures 
 
 and the values specified here are also the default values for these parameters.
 
+Finally, we have the parameter
+
+.. code-block:: ini
+
+    fail_if_not_converged = False
+
+which determines, whether the line search is terminated if the state system cannot be solved at the current iterate. If this is :ini:`fail_if_not_converged = True`, then an exception is raised. Otherwise, the iterate is counted as having too high of a function value and the stepsize is "halved" and a new iterate is formed.
+
 .. _config_ocp_algolbfgs:
 
 Section AlgoLBFGS
@@ -688,6 +696,9 @@ in the following.
       - Safeguard for stepsize, upper bound
     * - :ini:`factor_low = 0.1`
       - Safeguard for stepsize, lower bound
+    * - :ini:`fail_if_not_converged = False`
+      - if this is :ini:`True`, then the line search fails if the state system can not be solved at the new iterate
+
 
 [AlgoLBFGS]
 ***********

--- a/docs/source/user/demos/shape_optimization/doc_config.rst
+++ b/docs/source/user/demos/shape_optimization/doc_config.rst
@@ -356,6 +356,14 @@ For the polynomial models, we also have a safeguarding procedure, which ensures 
 
 and the values specified here are also the default values for these parameters.
 
+Finally, we have the parameter
+
+.. code-block:: ini
+
+    fail_if_not_converged = False
+
+which determines, whether the line search is terminated if the state system cannot be solved at the current iterate. If this is :ini:`fail_if_not_converged = True`, then an exception is raised. Otherwise, the iterate is counted as having too high of a function value and the stepsize is "halved" and a new iterate is formed.
+
 .. _config_shape_algolbfgs:
 
 Section AlgoLBFGS
@@ -1128,7 +1136,6 @@ in the following.
       - :ini:`picard_verbose = True` enables verbose output of Picard iteration
 
 
-
 [OptimizationRoutine]
 *********************
 
@@ -1178,7 +1185,8 @@ in the following.
       - Safeguard for stepsize, upper bound
     * - :ini:`factor_low = 0.1`
       - Safeguard for stepsize, lower bound
-
+    * - :ini:`fail_if_not_converged = False`
+      - if this is :ini:`True`, then the line search fails if the state system can not be solved at the new iterate
       
 [AlgoLBFGS]
 ***********


### PR DESCRIPTION
This parameter determines, whether the line search is cancelled once the state system cannot be solved at a (trial) iterate. If this is True, then the line search is cancelled. Otherwise, the step size is "halved" and a new iterate is generated.