### PR TITLE
Add keyword arguments pre_callback and post_callback to optimization problems

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ of the maintenance releases, please take a look at
 2.1.0 (in development)
 ----------------------
 
+* Add the keyword arguments :py:`pre_callback` and :py:`post_callback` to define callbacks when an optimization problem is instanciated.
+
 * New configuration file parameters:
 
   * Section LineSearch

--- a/cashocs/_optimization/optimal_control/optimal_control_problem.py
+++ b/cashocs/_optimization/optimal_control/optimal_control_problem.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, TYPE_CHECKING, Union
+from typing import Callable, List, Optional, TYPE_CHECKING, Union
 
 import fenics
 import numpy as np
@@ -87,6 +87,8 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
             ]
         ] = None,
         preconditioner_forms: Optional[Union[List[ufl.Form], ufl.Form]] = None,
+        pre_callback: Optional[Callable] = None,
+        post_callback: Optional[Callable] = None,
     ) -> None:
         r"""Initializes self.
 
@@ -142,6 +144,10 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
             preconditioner_forms: The list of forms for the preconditioner. The default
                 is `None`, so that the preconditioner matrix is the same as the system
                 matrix.
+            pre_callback: A function (without arguments) that will be called before each
+                solve of the state system
+            post_callback: A function (without arguments) that will be called after the
+                computation of the gradient.
 
         Examples:
             Examples how to use this class can be found in the :ref:`tutorial
@@ -161,6 +167,8 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
             gradient_ksp_options=gradient_ksp_options,
             desired_weights=desired_weights,
             preconditioner_forms=preconditioner_forms,
+            pre_callback=pre_callback,
+            post_callback=post_callback,
         )
 
         self.db.function_db.controls = _utils.enlist(controls)

--- a/cashocs/_optimization/optimization_problem.py
+++ b/cashocs/_optimization/optimization_problem.py
@@ -104,6 +104,8 @@ class OptimizationProblem(abc.ABC):
         temp_dict: Optional[Dict] = None,
         initial_function_values: Optional[List[float]] = None,
         preconditioner_forms: Optional[Union[List[ufl.Form], ufl.Form]] = None,
+        pre_callback: Optional[Callable] = None,
+        post_callback: Optional[Callable] = None,
     ) -> None:
         r"""Initializes self.
 
@@ -154,6 +156,10 @@ class OptimizationProblem(abc.ABC):
             preconditioner_forms: The list of forms for the preconditioner. The default
                 is `None`, so that the preconditioner matrix is the same as the system
                 matrix.
+            pre_callback: A function (without arguments) that will be called before each
+                solve of the state system
+            post_callback: A function (without arguments) that will be called after the
+                computation of the gradient.
 
         Notes:
             If one uses a single PDE constraint, the inputs can be the objects
@@ -220,6 +226,10 @@ class OptimizationProblem(abc.ABC):
             self.bcs_list,
             self.preconditioner_forms,
         )
+
+        self.db.callback.pre_callback = pre_callback
+        self.db.callback.post_callback = post_callback
+
         if temp_dict is not None:
             self.db.parameter_db.temp_dict.update(temp_dict)
             self.db.parameter_db.is_remeshed = True

--- a/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
+++ b/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
@@ -94,6 +94,8 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
         temp_dict: Optional[Dict] = None,
         initial_function_values: Optional[List[float]] = None,
         preconditioner_forms: Optional[Union[List[ufl.Form], ufl.Form]] = None,
+        pre_callback: Optional[Callable] = None,
+        post_callback: Optional[Callable] = None,
     ) -> None:
         """Initializes self.
 
@@ -152,6 +154,10 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
             preconditioner_forms: The list of forms for the preconditioner. The default
                 is `None`, so that the preconditioner matrix is the same as the system
                 matrix.
+            pre_callback: A function (without arguments) that will be called before each
+                solve of the state system
+            post_callback: A function (without arguments) that will be called after the
+                computation of the gradient.
 
         """
         super().__init__(
@@ -169,6 +175,8 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
             temp_dict=temp_dict,
             initial_function_values=initial_function_values,
             preconditioner_forms=preconditioner_forms,
+            pre_callback=pre_callback,
+            post_callback=post_callback,
         )
 
         if shape_scalar_product is None:

--- a/cashocs/_optimization/topology_optimization/topology_optimization_problem.py
+++ b/cashocs/_optimization/topology_optimization/topology_optimization_problem.py
@@ -80,6 +80,8 @@ class TopologyOptimizationProblem(_optimization.OptimizationProblem):
             Union[_typing.KspOption, List[_typing.KspOption]]
         ] = None,
         desired_weights: list[float] | None = None,
+        pre_callback: Optional[Callable] = None,
+        post_callback: Optional[Callable] = None,
     ) -> None:
         r"""Initializes the topology optimization problem.
 
@@ -132,6 +134,10 @@ class TopologyOptimizationProblem(_optimization.OptimizationProblem):
                 magnitude of `desired_weights[i]` for the initial iteration. In case
                 that `desired_weights` is `None`, no scaling is performed. Default is
                 `None`.
+            pre_callback: A function (without arguments) that will be called before each
+                solve of the state system
+            post_callback: A function (without arguments) that will be called after the
+                computation of the gradient.
 
         """
         super().__init__(
@@ -146,6 +152,8 @@ class TopologyOptimizationProblem(_optimization.OptimizationProblem):
             adjoint_ksp_options=adjoint_ksp_options,
             gradient_ksp_options=gradient_ksp_options,
             desired_weights=desired_weights,
+            pre_callback=pre_callback,
+            post_callback=post_callback,
         )
 
         self.db.parameter_db.problem_type = "topology"

--- a/demos/documented/optimal_control/pre_post_callbacks/demo_pre_post_callbacks.py
+++ b/demos/documented/optimal_control/pre_post_callbacks/demo_pre_post_callbacks.py
@@ -142,10 +142,8 @@ def pre_callback():
 
 
 # where we solve the Navier-Stokes equations with a lower Reynolds number of
-# {python}`Re / 10.0`. Later on, we inject this {python}`pre_callback` into cashocs by
-# using the
-# {py:meth}`inject_pre_callback <cashocs.OptimalControlProblem.inject_pre_callback>`
-# method.
+# {python}`Re / 10.0`. Later on, we use this function as keyword argument for defining
+# the optimization problem.
 #
 # Additionally, cashocs implements the functionality of also performing a pre-defined
 # action after each gradient computation, given by a so-called {python}`post_callback`.
@@ -157,26 +155,39 @@ def post_callback():
     print("Performing an action after computing the gradient.")
 
 
-# Next, before we can inject these two callbacks, we first have to define the optimal
-# control problem
+# Next, we define the optimization and use the keyword arguments to define the callbacks
+# via
 
-ocp = cashocs.OptimalControlProblem(e, bcs, J, up, c, vq, config=config)
-
-# Finally, we can inject both hooks via
-
-ocp.inject_pre_callback(pre_callback)
-ocp.inject_post_callback(post_callback)
+ocp = cashocs.OptimalControlProblem(
+    e,
+    bcs,
+    J,
+    up,
+    c,
+    vq,
+    config=config,
+    pre_callback=pre_callback,
+    post_callback=post_callback,
+)
 
 # ::::{note}
-# We can also save one line and use the code
-# :::python
+# Alternatively, the pre- and post-callbacks can be injected to an already defined
+# optimization problem with the code
+#
+# :::{code-block} python
+# ocp.inject_pre_callback(pre_callback)
+# ocp.inject_post_callback(post_callback)
+# :::
+#
+# or, equivalently,
+#
+# :::{code-block} python
 # ocp.inject_pre_post_hook(pre_hook, post_hook)
 # :::
 #
-# which is equivalent to the above two lines.
 # ::::
-#
-# And in the end, we solve the problem with
+
+# In the end, we solve the problem with
 
 ocp.solve()
 


### PR DESCRIPTION
This PR adds the keyword arguments "pre_callback" and "post_callback" to optimization problems, which allows users to define the callbacks directly when instanciating the optimization problem.