### PR TITLE
Fix an issue with the fail_if_not_converged parameter

### DIFF
--- a/cashocs/_optimization/line_search/armijo_line_search.py
+++ b/cashocs/_optimization/line_search/armijo_line_search.py
@@ -195,6 +195,6 @@ class ArmijoLineSearch(line_search.LineSearch):
             if self.config.getboolean("LineSearch", "fail_if_not_converged"):
                 raise error
             else:
-                objective_step = 2.0 * current_function_value
+                objective_step = 2.0 * abs(current_function_value)
 
         return objective_step


### PR DESCRIPTION
When the cost functional was negative, a not converged solution did actually decrease the cost functional further, which was not intended.