### PR TITLE
Fix PETSc version to <= 3.17.4 as a temporary workaround

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update --fix-missing \
   && rm -rf /var/lib/apt/lists/*
 
 RUN conda install -c conda-forge mamba \
-  && mamba create -n cashocs -c conda-forge fenics=2019 meshio">=5.0.0" pytest">=7.0.0" gmsh">=4.8" "occt<=7.7.0" coverage">=6.1.0" mpich python=3.11 \
+  && mamba create -n cashocs -c conda-forge fenics=2019 meshio">=5.0.0" pytest">=7.0.0" gmsh">=4.8" "occt<=7.7.0" petsc"<=3.17.4" coverage">=6.1.0" mpich python=3.11 \
   && conda clean --all --yes
 
 

--- a/.github/workflows/test_demos.yml
+++ b/.github/workflows/test_demos.yml
@@ -29,6 +29,7 @@ jobs:
           pytest">=7.0.0"
           gmsh">=4.8"
           occt"<=7.7.0"
+          petsc"<=3.17.4"
           matplotlib
           python=3.11
 
@@ -67,6 +68,7 @@ jobs:
           pytest">=7.0.0"
           gmsh">=4.8"
           occt"<=7.7.0"
+          petsc"<=3.17.4"
           mpich
           matplotlib
           python=3.11

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -33,6 +33,7 @@ jobs:
           pytest">=7.0.0"
           gmsh">=4.8"
           occt"<=7.7.0"
+          petsc"<=3.17.4"
 
     - name: Install package
       run: |

--- a/.github/workflows/tests_parallel.yml
+++ b/.github/workflows/tests_parallel.yml
@@ -36,6 +36,7 @@ jobs:
           pytest">=7.0.0"
           gmsh">=4.8"
           occt"<=7.7.0"
+          petsc"<=3.17.4"
           ${{ matrix.mpi }}
           python=${{ matrix.python-version }}
 

--- a/.github/workflows/tests_serial.yml
+++ b/.github/workflows/tests_serial.yml
@@ -33,6 +33,7 @@ jobs:
           pytest">=7.0.0"
           gmsh">=4.8"
           occt"<=7.7.0"
+          petsc"<=3.17.4"
           python=${{ matrix.python-version }}
 
     - name: Install package


### PR DESCRIPTION
This PR fixes the PETSc version because there are issues with PETSc 3.18 (on conda-forge at least). 
See https://github.com/conda-forge/fenics-feedstock/issues/180