### PR TITLE
Use a different criterion for the BFGS curvature test

### DIFF
--- a/cashocs/_optimization/optimization_algorithms/l_bfgs.py
+++ b/cashocs/_optimization/optimization_algorithms/l_bfgs.py
@@ -263,7 +263,7 @@ class LBFGSMethod(optimization_algorithm.OptimizationAlgorithm):
             if not self.damped:
                 self.history_y.appendleft([x.copy(True) for x in self.y_k])
                 self.history_s.appendleft([x.copy(True) for x in self.s_k])
-                if curvature_condition < 1e-4 * gamma:
+                if curvature_condition <= 0.0:
                     self.has_curvature_info = False
                     self.history_s.clear()
                     self.history_y.clear()


### PR DESCRIPTION
Now, the criterion is an absolute one, in contrast to the previous implementation, where a relative one was used. 
If a relative criterion is desired, damped BFGS should be chosen.