### PR TITLE
Add configuration parameter "remesh_iter" to Section "MeshQuality"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ of the maintenance releases, please take a look at
 
     * :ini:`fail_if_not_converged` determines, whether the line search is cancelled once the state system cannot be solved or if a new iterate is tried instead.
 
+  * Section MeshQuality
+
+    * :ini:`remesh_iter` is used to perform a remeshing after a certain amount of iterations.
+
 
 
 2.0.0 (May 16, 2023)

--- a/cashocs/_optimization/shape_optimization/shape_variable_abstractions.py
+++ b/cashocs/_optimization/shape_optimization/shape_variable_abstractions.py
@@ -144,10 +144,22 @@ class ShapeVariableAbstractions(
             A boolean, which indicates whether remeshing is required.
 
         """
-        return bool(
+        mesh_quality_criterion = bool(
             self.mesh_handler.current_mesh_quality
             < self.mesh_handler.mesh_quality_tol_upper
         )
+
+        iteration = self.db.parameter_db.optimization_state["iteration"]
+        if self.db.config.getint("MeshQuality", "remesh_iter") > 0:
+            iteration_criterion = bool(
+                iteration > 0
+                and iteration % self.db.config.getint("MeshQuality", "remesh_iter") == 0
+            )
+        else:
+            iteration_criterion = False
+
+        requires_remeshing = mesh_quality_criterion or iteration_criterion
+        return requires_remeshing
 
     def project_ncg_search_direction(
         self, search_direction: List[fenics.Function]

--- a/cashocs/io/config.py
+++ b/cashocs/io/config.py
@@ -462,6 +462,10 @@ class Config(ConfigParser):
                     "type": "str",
                     "possible_options": ["min", "avg", "minimum", "average"],
                 },
+                "remesh_iter": {
+                    "type": "int",
+                    "attributes": ["non_negative"],
+                },
             },
             "TopologyOptimization": {
                 "angle_tol": {
@@ -637,6 +641,7 @@ measure = skewness
 type = min
 volume_change = inf
 angle_change = inf
+remesh_iter = 0
 
 [TopologyOptimization]
 angle_tol = 1.0

--- a/docs/source/user/demos/shape_optimization/doc_config.rst
+++ b/docs/source/user/demos/shape_optimization/doc_config.rst
@@ -963,7 +963,7 @@ Available options are
 (see :py:class:`MeshQuality <cashocs.MeshQuality>` for a detailed description).
 The default value is given by :ini:`measure = skewness`.
 
-Finally, the parameter :ini:`type` determines, whether the minimum quality over all
+The parameter :ini:`type` determines, whether the minimum quality over all
 elements (:ini:`type = min`) or the average quality over all elements (:ini:`type = avg`)
 shall be used. This is set via 
 
@@ -972,6 +972,14 @@ shall be used. This is set via
     type = min
 
 and defaults to :ini:`type = min`.
+
+Finally, we have the parameter :ini:`remesh_iter` in which the user can specify after how many iterations a remeshing should be performed. It is given by
+
+.. code-block:: ini
+
+    remesh_iter = 0
+
+where :ini:`remesh_iter = 0` means that no automatic remeshing is performed (this is the default), and :ini:`remesh_iter = n` means that remeshing is performed after each `n` iterations. Note that to use this parameter and avoid unexpected results, it might be beneficial to the the lower and upper mesh quality tolerances to a low value, so that the "quality based remeshing" does not interfere with the "iteration based remeshing", but both can be used in combination.
 
 .. _config_shape_output:
 


### PR DESCRIPTION
This PR adds the feature that automatic remeshing can be performed every `n` iterations, as specified by the new parameter "remesh_iter" in Section "MeshQuality".