### PR TITLE
Move to mambaorg/micromamba as docker base image for CI

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -15,7 +15,8 @@ RUN micromamba install -y -n base -c conda-forge \
       "occt<=7.7.0" \
       coverage">=6.1.0" \
       mpich \
-      python=3.11 && \
+      python=3.11 \
+      pip && \
    micromamba clean --all --yes
 
 

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -23,10 +23,8 @@ FROM test-env AS cashocs
 
 COPY . /root/cashocs
 
-RUN micromamba activate base && \
-    cd /root/cashocs && \
+RUN cd /root/cashocs && \
     pip install .[all]
 
-RUN micromamba activate base && \
-    cd /root/cashocs && \
+RUN cd /root/cashocs && \
     python3 -m pytest -vv tests/

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -25,10 +25,10 @@ SHELL ["/bin/bash", "--login", "-c"]
 
 COPY . /root/cashocs
 
-RUN mamba activate base && \
+RUN micromamba activate base && \
     cd /root/cashocs && \
     pip install .[all]
 
-RUN mamba activate base && \
+RUN micromamba activate base && \
     cd /root/cashocs && \
     python3 -m pytest -vv tests/

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM mambaorg/micromamba:1-jammy AS test-env
 
+USER root
+
 RUN apt-get update --fix-missing \
   && apt-get install -y libgl1-mesa-dev ffmpeg libsm6 libxext6 curl \
   && apt-get clean \

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -15,8 +15,7 @@ RUN micromamba install -y -n base -c conda-forge \
       "occt<=7.7.0" \
       coverage">=6.1.0" \
       mpich \
-      python=3.11 \
-      pip && \
+      python=3.11 && \
    micromamba clean --all --yes
 
 
@@ -26,8 +25,10 @@ SHELL ["/bin/bash", "--login", "-c"]
 
 COPY . /root/cashocs
 
-RUN cd /root/cashocs && \
+RUN mamba activate base && \
+    cd /root/cashocs && \
     pip install .[all]
 
-RUN cd /root/cashocs && \
+RUN mamba activate base && \
+    cd /root/cashocs && \
     python3 -m pytest -vv tests/

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -24,9 +24,7 @@ ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
 FROM test-env AS cashocs
 
-
 COPY --chown=$MAMBA_USER:$MAMBA_USER . /home/mambauser/cashocs
-
 
 RUN cd /home/mambauser/cashocs && \
     pip install .[all]

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -21,8 +21,6 @@ RUN micromamba install -y -n base -c conda-forge \
 
 FROM test-env AS cashocs
 
-SHELL ["/bin/bash", "--login", "-c"]
-
 COPY . /root/cashocs
 
 RUN micromamba activate base && \

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update --fix-missing && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+USER $MAMBA_USER
+
 RUN micromamba install -y -n base -c conda-forge \
       fenics=2019 \
       meshio">=5.0.0" \

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -20,10 +20,13 @@ RUN micromamba install -y -n base -c conda-forge \
       python=3.11 && \
    micromamba clean --all --yes
 
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
 FROM test-env AS cashocs
 
-COPY . "${HOME}/cashocs"
+USER $MAMBA_USER
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER . "${HOME}/cashocs"
 
 RUN cd "${HOME}/cashocs" && \
     pip install .[all]

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -26,7 +26,9 @@ FROM test-env AS cashocs
 
 USER $MAMBA_USER
 
-COPY --chown=$MAMBA_USER:$MAMBA_USER . "${HOME}/cashocs"
+COPY --chown=$MAMBA_USER:$MAMBA_USER . /tmp/cashocs
+
+RUN cp -R /tmp/cashocs "${HOME}/cashocs
 
 RUN cd "${HOME}/cashocs" && \
     pip install .[all]

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,13 +1,20 @@
-FROM continuumio/miniconda3:latest AS test-env
+FROM mambaorg/micromamba:1-jammy AS test-env
 
 RUN apt-get update --fix-missing \
   && apt-get install -y libgl1-mesa-dev ffmpeg libsm6 libxext6 curl \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN conda install -c conda-forge mamba \
-  && mamba create -n cashocs -c conda-forge fenics=2019 meshio">=5.0.0" pytest">=7.0.0" gmsh">=4.8" "occt<=7.7.0" coverage">=6.1.0" mpich python=3.11 \
-  && conda clean --all --yes
+RUN micromamba install -y -n base -c conda-forge \
+      fenics=2019 \
+      meshio">=5.0.0" \
+      pytest">=7.0.0" \
+      gmsh">=4.8" \
+      "occt<=7.7.0" \
+      coverage">=6.1.0" \
+      mpich \
+      python=3.11 \
+    micromamba clean --all --yes
 
 
 FROM test-env AS cashocs
@@ -16,10 +23,8 @@ SHELL ["/bin/bash", "--login", "-c"]
 
 COPY . /root/cashocs
 
-RUN conda activate cashocs \
-  && cd /root/cashocs \
+RUN cd /root/cashocs \
   && pip install .[all]
 
-RUN conda activate cashocs \
-  && cd /root/cashocs \
+RUN cd /root/cashocs \
   && python3 -m pytest -vv tests/

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -2,10 +2,10 @@ FROM mambaorg/micromamba:1-jammy AS test-env
 
 USER root
 
-RUN apt-get update --fix-missing \
-  && apt-get install -y libgl1-mesa-dev ffmpeg libsm6 libxext6 curl \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update --fix-missing && \
+    apt-get install -y libgl1-mesa-dev ffmpeg libsm6 libxext6 curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN micromamba install -y -n base -c conda-forge \
       fenics=2019 \
@@ -15,8 +15,8 @@ RUN micromamba install -y -n base -c conda-forge \
       "occt<=7.7.0" \
       coverage">=6.1.0" \
       mpich \
-      python=3.11 \
-    micromamba clean --all --yes
+      python=3.11 && \
+   micromamba clean --all --yes
 
 
 FROM test-env AS cashocs
@@ -25,8 +25,8 @@ SHELL ["/bin/bash", "--login", "-c"]
 
 COPY . /root/cashocs
 
-RUN cd /root/cashocs \
-  && pip install .[all]
+RUN cd /root/cashocs && \
+    pip install .[all]
 
-RUN cd /root/cashocs \
-  && python3 -m pytest -vv tests/
+RUN cd /root/cashocs && \
+    python3 -m pytest -vv tests/

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -23,10 +23,10 @@ RUN micromamba install -y -n base -c conda-forge \
 
 FROM test-env AS cashocs
 
-COPY . /root/cashocs
+COPY . "${HOME}/cashocs"
 
-RUN cd /root/cashocs && \
+RUN cd "${HOME}/cashocs" && \
     pip install .[all]
 
-RUN cd /root/cashocs && \
+RUN cd "${HOME}/cashocs" && \
     python3 -m pytest -vv tests/

--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -24,14 +24,12 @@ ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
 FROM test-env AS cashocs
 
-USER $MAMBA_USER
 
-COPY --chown=$MAMBA_USER:$MAMBA_USER . /tmp/cashocs
+COPY --chown=$MAMBA_USER:$MAMBA_USER . /home/mambauser/cashocs
 
-RUN cp -R /tmp/cashocs "${HOME}/cashocs
 
-RUN cd "${HOME}/cashocs" && \
+RUN cd /home/mambauser/cashocs && \
     pip install .[all]
 
-RUN cd "${HOME}/cashocs" && \
+RUN cd /home/mambauser/cashocs && \
     python3 -m pytest -vv tests/

--- a/.github/micromamba/testenv.yml
+++ b/.github/micromamba/testenv.yml
@@ -1,6 +1,5 @@
 name: test
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - numpy

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3.5.3
 
-
       - name: Get tag name
         id: tag_name
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Delete current installation in docker image
-      shell: /usr/local/bin/_dockerfile_shell.sh {0}
+      shell: bash -l {0}
       run: |
         pip uninstall -y cashocs
         rm -R /home/mambauser/cashocs
@@ -28,12 +28,12 @@ jobs:
       uses: actions/checkout@v3.5.3 
 
     - name: Install cashocs
-      shell: /usr/local/bin/_dockerfile_shell.sh {0}
+      shell: bash -l {0}
       run: |
         pip install .[all]
 
     - name: Run tests
-      shell: /usr/local/bin/_dockerfile_shell.sh {0}
+      shell: bash -l {0}
       run: |
         python3 -m pytest -vv --cov=cashocs --cov-report=xml tests/
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Delete current installation in docker image
-      shell: "/usr/local/bin/_dockerfile_shell.sh"
+      shell: /usr/local/bin/_dockerfile_shell.sh {0}
       run: |
         pip uninstall -y cashocs
         rm -R /home/mambauser/cashocs
@@ -28,12 +28,12 @@ jobs:
       uses: actions/checkout@v3.5.3 
 
     - name: Install cashocs
-      shell: "/usr/local/bin/_dockerfile_shell.sh"
+      shell: /usr/local/bin/_dockerfile_shell.sh {0}
       run: |
         pip install .[all]
 
     - name: Run tests
-      shell: "/usr/local/bin/_dockerfile_shell.sh"
+      shell: /usr/local/bin/_dockerfile_shell.sh {0}
       run: |
         python3 -m pytest -vv --cov=cashocs --cov-report=xml tests/
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Delete current installation in docker image
-      shell: /usr/local/bin/_dockerfile_shell.sh
+      shell: "/usr/local/bin/_dockerfile_shell.sh"
       run: |
         pip uninstall -y cashocs
         rm -R /home/mambauser/cashocs
@@ -28,12 +28,12 @@ jobs:
       uses: actions/checkout@v3.5.3 
 
     - name: Install cashocs
-      shell: /usr/local/bin/_dockerfile_shell.sh
+      shell: "/usr/local/bin/_dockerfile_shell.sh"
       run: |
         pip install .[all]
 
     - name: Run tests
-      shell: /usr/local/bin/_dockerfile_shell.sh
+      shell: "/usr/local/bin/_dockerfile_shell.sh"
       run: |
         python3 -m pytest -vv --cov=cashocs --cov-report=xml tests/
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
     - name: Delete current installation in docker image
       shell: bash -l {0}
       run: |
-        conda activate cashocs
         pip uninstall -y cashocs
         rm -R /root/cashocs
 
@@ -31,13 +30,11 @@ jobs:
     - name: Install cashocs
       shell: bash -l {0}
       run: |
-        conda activate cashocs
         pip install .[all]
 
     - name: Run tests
       shell: bash -l {0}
       run: |
-        conda activate cashocs
         python3 -m pytest -vv --cov=cashocs --cov-report=xml tests/
 
     - name: Upload coverage to codecov.io

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
         rm -R /home/mambauser/cashocs
 
     - name: Checkout repository
+      shell: bash
       uses: actions/checkout@v3.5.3 
 
     - name: Install cashocs
@@ -41,11 +42,13 @@ jobs:
         python3 -m pytest -vv --cov=cashocs --cov-report=xml tests/
 
     - name: Upload coverage to codecov.io
+      shell: bash
       uses: codecov/codecov-action@v3
       with:
         files: coverage.xml
 
     - name: Upload coverage to codacy
+      shell: bash
       uses: codacy/codacy-coverage-reporter-action@v1
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,13 +15,13 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sblauth/cashocs:main
+      image: ghcr.io/sblauth/cashocs:cifix-dockerfile
 
     steps:
     - name: Delete current installation in docker image
       run: |
         pip uninstall -y cashocs
-        rm -R /root/cashocs
+        rm -R /home/mambauser/cashocs
 
     - name: Checkout repository
       uses: actions/checkout@v3.5.3 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,6 @@ jobs:
 
     steps:
     - name: Delete current installation in docker image
-      shell: bash -l {0}
       run: |
         pip uninstall -y cashocs
         rm -R /root/cashocs
@@ -28,12 +27,10 @@ jobs:
       uses: actions/checkout@v3.5.3 
 
     - name: Install cashocs
-      shell: bash -l {0}
       run: |
         pip install .[all]
 
     - name: Run tests
-      shell: bash -l {0}
       run: |
         python3 -m pytest -vv --cov=cashocs --cov-report=xml tests/
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sblauth/cashocs:cifix-dockerfile
+      options: --user=root
 
     steps:
     - name: Delete current installation in docker image
@@ -26,7 +27,6 @@ jobs:
         rm -R /home/mambauser/cashocs
 
     - name: Checkout repository
-      shell: bash
       uses: actions/checkout@v3.5.3 
 
     - name: Install cashocs
@@ -42,13 +42,11 @@ jobs:
         python3 -m pytest -vv --cov=cashocs --cov-report=xml tests/
 
     - name: Upload coverage to codecov.io
-      shell: bash
       uses: codecov/codecov-action@v3
       with:
         files: coverage.xml
 
     - name: Upload coverage to codacy
-      shell: bash
       uses: codacy/codacy-coverage-reporter-action@v1
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,8 @@ jobs:
 
     steps:
     - name: Delete current installation in docker image
+      shell: /usr/local/bin/_dockerfile_shell.sh
       run: |
-        micromamba activate base
         pip uninstall -y cashocs
         rm -R /home/mambauser/cashocs
 
@@ -28,10 +28,12 @@ jobs:
       uses: actions/checkout@v3.5.3 
 
     - name: Install cashocs
+      shell: /usr/local/bin/_dockerfile_shell.sh
       run: |
         pip install .[all]
 
     - name: Run tests
+      shell: /usr/local/bin/_dockerfile_shell.sh
       run: |
         python3 -m pytest -vv --cov=cashocs --cov-report=xml tests/
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,9 @@ jobs:
 
     steps:
     - name: Delete current installation in docker image
+      shell: bash
       run: |
+        source /usr/local/bin/_entrypoint.sh
         pip uninstall -y cashocs
         rm -R /home/mambauser/cashocs
 
@@ -27,11 +29,15 @@ jobs:
       uses: actions/checkout@v3.5.3 
 
     - name: Install cashocs
+      shell: bash
       run: |
+        source /usr/local/bin/_entrypoint.sh
         pip install .[all]
 
     - name: Run tests
+      shell: bash
       run: |
+        source /usr/local/bin/_entrypoint.sh
         python3 -m pytest -vv --cov=cashocs --cov-report=xml tests/
 
     - name: Upload coverage to codecov.io

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Delete current installation in docker image
       shell: bash -l {0}
       run: |
+        mamba activate base
         pip uninstall -y cashocs
         rm -R /root/cashocs
 
@@ -30,11 +31,13 @@ jobs:
     - name: Install cashocs
       shell: bash -l {0}
       run: |
+        mamba activate base
         pip install .[all]
 
     - name: Run tests
       shell: bash -l {0}
       run: |
+        mamba activate base
         python3 -m pytest -vv --cov=cashocs --cov-report=xml tests/
 
     - name: Upload coverage to codecov.io

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
     - name: Delete current installation in docker image
       run: |
+        micromamba activate base
         pip uninstall -y cashocs
         rm -R /home/mambauser/cashocs
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
     - name: Delete current installation in docker image
       shell: bash -l {0}
       run: |
-        mamba activate base
         pip uninstall -y cashocs
         rm -R /root/cashocs
 
@@ -31,13 +30,11 @@ jobs:
     - name: Install cashocs
       shell: bash -l {0}
       run: |
-        mamba activate base
         pip install .[all]
 
     - name: Run tests
       shell: bash -l {0}
       run: |
-        mamba activate base
         python3 -m pytest -vv --cov=cashocs --cov-report=xml tests/
 
     - name: Upload coverage to codecov.io

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sblauth/cashocs:cifix-dockerfile
+      image: ghcr.io/sblauth/cashocs:main
       options: --user=root
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,6 @@ jobs:
 
     steps:
     - name: Delete current installation in docker image
-      shell: bash -l {0}
       run: |
         pip uninstall -y cashocs
         rm -R /home/mambauser/cashocs
@@ -28,12 +27,10 @@ jobs:
       uses: actions/checkout@v3.5.3 
 
     - name: Install cashocs
-      shell: bash -l {0}
       run: |
         pip install .[all]
 
     - name: Run tests
-      shell: bash -l {0}
       run: |
         python3 -m pytest -vv --cov=cashocs --cov-report=xml tests/
 


### PR DESCRIPTION
This PR fixes an issue with the docker builds we have been experiencing the last couple of weeks. It comes from a compatibility issue between conda and mamba (when mixing default and conda-forge channels).

In this PR, a new docker image is used to define the "quick" tests, that run on every push (mambaorg/micromamba:1-jammy, so ubuntu).

This fixes the issue of the tests and the failing CI workflows