### PR TITLE
Change order of post_callback and gradient norm computation

### DIFF
--- a/cashocs/_pde_problems/shape_gradient_problem.py
+++ b/cashocs/_pde_problems/shape_gradient_problem.py
@@ -129,10 +129,6 @@ class ShapeGradientProblem(pde_problem.PDEProblem):
                 self.p_laplace_projector.solve()
                 self.has_solution = True
 
-                self.gradient_norm_squared = self.form_handler.scalar_product(
-                    self.db.function_db.gradient, self.db.function_db.gradient
-                )
-
             else:
                 self.form_handler.assembler.assemble(
                     self.form_handler.fe_shape_derivative_vector
@@ -153,11 +149,11 @@ class ShapeGradientProblem(pde_problem.PDEProblem):
 
                 self.has_solution = True
 
-                self.gradient_norm_squared = self.form_handler.scalar_product(
-                    self.db.function_db.gradient, self.db.function_db.gradient
-                )
-
             self.db.callback.call_post()
+
+            self.gradient_norm_squared = self.form_handler.scalar_product(
+                self.db.function_db.gradient, self.db.function_db.gradient
+            )
 
         return self.db.function_db.gradient
 


### PR DESCRIPTION
Now, post_callback will be called immediately after computing the gradient and the norm will be computed afterwards. This ensures correct norm computation, when the gradient is modified by the post_callback