### PR TITLE
Add version warning banners and (more) colors to the docs

### DIFF
--- a/docs/source/_static/cashocs.css
+++ b/docs/source/_static/cashocs.css
@@ -25,26 +25,6 @@ h3 {
 }
 
 
-/* Background of others should be red */
-.version-switcher__container {
-  position: relative;
-}
-
-.version-switcher__container span {
-  color: var(--pst-color-danger);
-}
-
-.version-switcher__container span:before {
-  content: "";
-  width: 100%;
-  height: 100%;
-  position: absolute;
-  left: 0;
-  top: 0;
-  background-color: var(--pst-color-danger);
-  opacity: 0.1;
-}
-
 /* Background of stable should be green */
 .version-switcher__container a[data-version-name*="stable"] {
   position: relative;
@@ -85,9 +65,26 @@ h3 {
   opacity: 0.1;
 }
 
+/* Background of others should be red */
+.version-switcher__container a:not([data-version-name*="dev"], [data-version-name*="stable"]) {
+  position: relative;
+}
 
-.version-switcher__button {
-   background-color: var(--pst-color-danger);
+.version-switcher__container a:not([data-version-name*="dev"], [data-version-name*="stable"]) span {
+  color: var(--pst-color-danger);
+}
+
+.version-switcher__container a:not([data-version-name*="dev"], [data-version-name*="stable"]) span:before {
+  content: "";
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  background-color: var(--pst-color-danger);
+  opacity: 0.1;
+}
+
 }
 
 .version-switcher__button[data-active-version-name*="dev"] {
@@ -98,6 +95,8 @@ h3 {
    background-color: var(--pst-color-success);
 }
 
+.version-switcher__button:not([data-activate-version-name*="dev"], [data-active-version-name*="stable"]) {
+   background-color: var(--pst-color-danger);
 
 
 /* Main page overview cards */

--- a/docs/source/_static/cashocs.css
+++ b/docs/source/_static/cashocs.css
@@ -87,17 +87,6 @@ h3 {
 
 }
 
-.version-switcher__button[data-active-version-name*="dev"] {
-   background-color: #E69F00;
-}
-
-.version-switcher__button[data-active-version-name*="stable"] {
-   background-color: var(--pst-color-success);
-}
-
-.version-switcher__button:not([data-activate-version-name*="dev"], [data-active-version-name*="stable"]) {
-   background-color: var(--pst-color-danger);
-
 
 /* Main page overview cards */
 

--- a/docs/source/_static/cashocs.css
+++ b/docs/source/_static/cashocs.css
@@ -25,6 +25,26 @@ h3 {
 }
 
 
+/* Background of others should be red */
+.version-switcher__container {
+  position: relative;
+}
+
+.version-switcher__container span {
+  color: var(--pst-color-danger);
+}
+
+.version-switcher__container span:before {
+  content: "";
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+  background-color: var(--pst-color-danger);
+  opacity: 0.1;
+}
+
 /* Background of stable should be green */
 .version-switcher__container a[data-version-name*="stable"] {
   position: relative;
@@ -64,6 +84,8 @@ h3 {
   background-color: #E69F00;
   opacity: 0.1;
 }
+
+
 
 
 /* Main page overview cards */

--- a/docs/source/_static/cashocs.css
+++ b/docs/source/_static/cashocs.css
@@ -86,6 +86,18 @@ h3 {
 }
 
 
+.version-switcher__button {
+   background-color: var(--pst-color-danger);
+}
+
+.version-switcher__button[data-active-version-name*="dev"] {
+   background-color: #E69F00;
+}
+
+.version-switcher__button[data-active-version-name*="stable"] {
+   background-color: var(--pst-color-success);
+}
+
 
 
 /* Main page overview cards */

--- a/docs/source/_static/version_switcher.json
+++ b/docs/source/_static/version_switcher.json
@@ -7,7 +7,8 @@
     {
         "name": "2.0 (stable)",
         "version": "2.0.11",
-        "url": "https://cashocs.readthedocs.io/en/v2.0.11/"
+        "url": "https://cashocs.readthedocs.io/en/v2.0.11/",
+        "preferred": true,
     },    
     {
         "name": "1.8",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -136,6 +136,7 @@ html_theme_options = {
     ],
     "logo": {"text": "cashocs", "alt_text": "cashocs"},
     "navbar_align": "content",
+    "show_version_warning_banner": True,
 }
 
 html_sidebars = {"**": ["search-field.html", "sidebar-nav-bs", "sidebar-ethical-ads"]}


### PR DESCRIPTION
This PR first adds version warning banners, as implemented in the pydata sphinx theme 0.14.
Additionally, the version switcher is now colored properly (bugs in the pydata sphinx theme have prevented this previously).

Closes #199 