### PR TITLE
CI: Remove occt pin, update pins for meshio and pytest

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -11,11 +11,10 @@ USER $MAMBA_USER
 
 RUN micromamba install -y -n base -c conda-forge \
       fenics=2019 \
-      meshio">=5.0.0" \
-      pytest">=7.0.0" \
+      meshio">=5.3.0" \
+      pytest">=7.2.0" \
       gmsh">=4.8" \
-      "occt<=7.7.0" \
-      coverage">=6.1.0" \
+      coverage">=7.1.0" \
       mpich \
       petsc"<=3.19" \
       python=3.11 && \

--- a/.github/workflows/test_demos.yml
+++ b/.github/workflows/test_demos.yml
@@ -25,10 +25,9 @@ jobs:
         environment-file: .github/micromamba/testenv.yml
         create-args: >-
           fenics=2019
-          meshio>=5.0.0
-          pytest>=7.0.0
+          meshio>=5.3.0
+          pytest>=7.2.0
           gmsh>=4.8
-          occt<=7.7.0
           matplotlib
           petsc"<=3.19"
           python=3.11
@@ -64,10 +63,9 @@ jobs:
         environment-file: .github/micromamba/testenv.yml
         create-args: >-
           fenics=2019
-          meshio>=5.0.0
-          pytest>=7.0.0
+          meshio>=5.3.0
+          pytest>=7.2.0
           gmsh>=4.8
-          occt<=7.7.0
           mpich
           matplotlib
           petsc"<=3.19"

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -29,10 +29,9 @@ jobs:
         create-args: >-
           python=${{ matrix.python-version }}
           fenics=2019
-          meshio>=5.0.0
-          pytest>=7.0.0
+          meshio>=5.3.0
+          pytest>=7.2.0
           gmsh>=4.8
-          occt<=7.7.0
           petsc<=3.19
 
     - name: Install package

--- a/.github/workflows/tests_parallel.yml
+++ b/.github/workflows/tests_parallel.yml
@@ -32,10 +32,9 @@ jobs:
         environment-file: .github/micromamba/testenv.yml
         create-args: >-
           fenics=2019
-          meshio>=5.0.0
-          pytest>=7.0.0
+          meshio>=5.3.0
+          pytest>=7.2.0
           gmsh>=4.8
-          occt<=7.7.0
           petsc<=3.19
           ${{ matrix.mpi }}
           python=${{ matrix.python-version }}

--- a/.github/workflows/tests_serial.yml
+++ b/.github/workflows/tests_serial.yml
@@ -29,10 +29,9 @@ jobs:
         environment-file: .github/micromamba/testenv.yml
         create-args: >-
           fenics=2019
-          meshio>=5.0.0
-          pytest>=7.0.0
+          meshio>=5.3.0
+          pytest>=7.2.0
           gmsh>=4.8
-          occt<=7.7.0
           petsc<=3.19
           python=${{ matrix.python-version }}
 


### PR DESCRIPTION
This PR updates the pinned packages for the CI workflows. 
It tries to remove the occt pin and updates the pins for meshio and pytest.