### PR TITLE
Pin mpi4py to versions <= 3.1.4

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -17,6 +17,7 @@ RUN micromamba install -y -n base -c conda-forge \
       coverage">=7.1.0" \
       mpich \
       petsc"<=3.19" \
+      mpi4py"<=3.1.4" \
       python=3.11 && \
    micromamba clean --all --yes
 

--- a/.github/workflows/test_demos.yml
+++ b/.github/workflows/test_demos.yml
@@ -30,6 +30,7 @@ jobs:
           gmsh>=4.8
           matplotlib
           petsc<=3.19
+          mpi4py<=3.1.4
           python=3.11
 
     - name: Install package
@@ -69,6 +70,7 @@ jobs:
           mpich
           matplotlib
           petsc<=3.19
+          mpi4py<=3.1.4
           python=3.11
 
     - name: Install package

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -33,6 +33,7 @@ jobs:
           pytest>=7.2.0
           gmsh>=4.8
           petsc<=3.19
+          mpi4py<=3.1.4
 
     - name: Install package
       run: |

--- a/.github/workflows/tests_parallel.yml
+++ b/.github/workflows/tests_parallel.yml
@@ -36,6 +36,7 @@ jobs:
           pytest>=7.2.0
           gmsh>=4.8
           petsc<=3.19
+          mpi4py<=3.1.4
           ${{ matrix.mpi }}
           python=${{ matrix.python-version }}
 

--- a/.github/workflows/tests_serial.yml
+++ b/.github/workflows/tests_serial.yml
@@ -33,6 +33,7 @@ jobs:
           pytest>=7.2.0
           gmsh>=4.8
           petsc<=3.19
+          mpi4py<=3.1.4
           python=${{ matrix.python-version }}
 
     - name: Install package


### PR DESCRIPTION
This is done to ensure that cashocs works as expected under Python 3.9 and 3.10, see #333 

Once the issue in mpi4py is fixed, this pin can be removed.