### PR TITLE
Remove the pin on mpi4py

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -17,7 +17,6 @@ RUN micromamba install -y -n base -c conda-forge \
       coverage">=7.1.0" \
       mpich \
       petsc"<=3.19" \
-      mpi4py"<=3.1.4" \
       python=3.11 && \
    micromamba clean --all --yes
 

--- a/.github/workflows/test_demos.yml
+++ b/.github/workflows/test_demos.yml
@@ -30,7 +30,6 @@ jobs:
           gmsh>=4.8
           matplotlib
           petsc<=3.19
-          mpi4py<=3.1.4
           python=3.11
 
     - name: Install package
@@ -70,7 +69,6 @@ jobs:
           mpich
           matplotlib
           petsc<=3.19
-          mpi4py<=3.1.4
           python=3.11
 
     - name: Install package

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -33,7 +33,6 @@ jobs:
           pytest>=7.2.0
           gmsh>=4.8
           petsc<=3.19
-          mpi4py<=3.1.4
 
     - name: Install package
       run: |

--- a/.github/workflows/tests_parallel.yml
+++ b/.github/workflows/tests_parallel.yml
@@ -36,7 +36,6 @@ jobs:
           pytest>=7.2.0
           gmsh>=4.8
           petsc<=3.19
-          mpi4py<=3.1.4
           ${{ matrix.mpi }}
           python=${{ matrix.python-version }}
 

--- a/.github/workflows/tests_serial.yml
+++ b/.github/workflows/tests_serial.yml
@@ -33,7 +33,6 @@ jobs:
           pytest>=7.2.0
           gmsh>=4.8
           petsc<=3.19
-          mpi4py<=3.1.4
           python=${{ matrix.python-version }}
 
     - name: Install package


### PR DESCRIPTION
This removes the pin from the mpi4py package. It seems that the intel MPI provider introduced in mpi4py 3.1.5 was not implemented correctly (see https://github.com/conda-forge/mpi-feedstock/issues/11) and the corresponding packages on conda-forge have been marked as broken.

This PR is intended to test, whether everything works OK again - and if that's the case, then the pin of mpi4py can be lifted.

Closes #333 