### PR TITLE
Add a config file parameter "global_deformation" for the deformation

### DIFF
--- a/cashocs/_optimization/line_search/line_search.py
+++ b/cashocs/_optimization/line_search/line_search.py
@@ -110,7 +110,9 @@ class LineSearch(abc.ABC):
         deformation, is_remeshed = self.search(
             solver, search_direction, has_curvature_info
         )
-        if deformation is not None:
+        if deformation is not None and self.config.getboolean(
+            "ShapeGradient", "global_deformation"
+        ):
             x = fenics.as_backend_type(deformation.vector()).vec()
 
             if not is_remeshed:

--- a/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
+++ b/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
@@ -190,7 +190,8 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
             fenics.Function(self.db.function_db.control_spaces[0])
         ]
         self.db.parameter_db.problem_type = "shape"
-        self.db.geometry_db.init_transfer_matrix()
+        if self.config.getboolean("ShapeGradient", "global_deformation"):
+            self.db.geometry_db.init_transfer_matrix()
 
         # Initialize the remeshing behavior, and a temp file
         self.do_remesh = self.config.getboolean("Mesh", "remesh")
@@ -350,8 +351,9 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
         else:
             raise _exceptions.CashocsException("This code cannot be reached.")
 
-        self.global_deformation_vector = line_search.global_deformation_vector
-        self.global_deformation_function = line_search.deformation_function
+        if self.config.getboolean("ShapeGradient", "global_deformation"):
+            self.global_deformation_vector = line_search.global_deformation_vector
+            self.global_deformation_function = line_search.deformation_function
 
         if self.algorithm.casefold() == "gradient_descent":
             solver: optimization_algorithms.OptimizationAlgorithm = (

--- a/cashocs/geometry/mesh_handler.py
+++ b/cashocs/geometry/mesh_handler.py
@@ -695,24 +695,27 @@ class _MeshHandler:
             solver: The optimization algorithm.
 
         """
-        pre_log_level = (
-            _loggers._cashocs_logger.level  # pylint: disable=protected-access
-        )
-        _loggers.set_log_level(_loggers.LogLevel.WARNING)
-        mesh, _, _, _, _, _ = import_mesh(xdmf_filename)
-        _loggers.set_log_level(pre_log_level)
+        if self.config.getboolean("ShapeGradient", "global_deformation"):
+            pre_log_level = (
+                _loggers._cashocs_logger.level  # pylint: disable=protected-access
+            )
+            _loggers.set_log_level(_loggers.LogLevel.WARNING)
+            mesh, _, _, _, _, _ = import_mesh(xdmf_filename)
+            _loggers.set_log_level(pre_log_level)
 
-        deformation_space = fenics.VectorFunctionSpace(mesh, "CG", 1)
-        interpolator = _utils.Interpolator(
-            deformation_space, self.db.function_db.control_spaces[0]
-        )
-        new_transfer_matrix = self.db.geometry_db.transfer_matrix.matMult(
-            interpolator.transfer_matrix
-        )
-        self.db.parameter_db.temp_dict["transfer_matrix"] = new_transfer_matrix.copy()
-        self.db.parameter_db.temp_dict[
-            "old_transfer_matrix"
-        ] = self.db.geometry_db.transfer_matrix.copy()
-        self.db.parameter_db.temp_dict[
-            "deformation_function"
-        ] = solver.line_search.deformation_function.copy(True)
+            deformation_space = fenics.VectorFunctionSpace(mesh, "CG", 1)
+            interpolator = _utils.Interpolator(
+                deformation_space, self.db.function_db.control_spaces[0]
+            )
+            new_transfer_matrix = self.db.geometry_db.transfer_matrix.matMult(
+                interpolator.transfer_matrix
+            )
+            self.db.parameter_db.temp_dict[
+                "transfer_matrix"
+            ] = new_transfer_matrix.copy()
+            self.db.parameter_db.temp_dict[
+                "old_transfer_matrix"
+            ] = self.db.geometry_db.transfer_matrix.copy()
+            self.db.parameter_db.temp_dict[
+                "deformation_function"
+            ] = solver.line_search.deformation_function.copy(True)

--- a/cashocs/io/config.py
+++ b/cashocs/io/config.py
@@ -368,6 +368,9 @@ class Config(ConfigParser):
                 "degree_estimation": {
                     "type": "bool",
                 },
+                "global_deformation": {
+                    "type": "bool",
+                },
             },
             "Regularization": {
                 "factor_volume": {
@@ -595,6 +598,7 @@ shape_bdry_fix = []
 shape_bdry_fix_x = []
 shape_bdry_fix_y = []
 shape_bdry_fix_z = []
+global_deformation = False
 
 [Regularization]
 factor_volume = 0.0

--- a/tests/test_shape_optimization.py
+++ b/tests/test_shape_optimization.py
@@ -1102,6 +1102,7 @@ def test_stepsize2():
 
 def test_global_deformation():
     config = cashocs.load_config(dir_path + "/config_sop.ini")
+    config.set("ShapeGradient", "global_deformation", "True")
 
     mesh.coordinates()[:, :] = initial_coordinates
     mesh.bounding_box_tree().build(mesh)


### PR DESCRIPTION
This is set to False as default so that `fenics.PETScDMCollection.create_transfer_matrix` is as called as little as possible, as this function sometimes gives segfaults.