### PR TITLE
Rename APosterioriTester to IntersectionTester and add a config parameter

### DIFF
--- a/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
+++ b/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
@@ -233,12 +233,10 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
             }
 
         a_priori_tester = mesh_testing.APrioriMeshTester(self.db.geometry_db.mesh)
-        a_posteriori_tester = mesh_testing.APosterioriMeshTester(
-            self.db.geometry_db.mesh
-        )
+        intersection_tester = mesh_testing.IntersectionTester(self.db.geometry_db.mesh)
         # pylint: disable=protected-access
         self.mesh_handler: geometry._MeshHandler = geometry._MeshHandler(
-            self.db, self.form_handler, a_priori_tester, a_posteriori_tester
+            self.db, self.form_handler, a_priori_tester, intersection_tester
         )
 
         self.state_spaces = self.db.function_db.state_spaces

--- a/cashocs/geometry/mesh_handler.py
+++ b/cashocs/geometry/mesh_handler.py
@@ -113,7 +113,7 @@ class _MeshHandler:
         db: database.Database,
         form_handler: _forms.ShapeFormHandler,
         a_priori_tester: mesh_testing.APrioriMeshTester,
-        a_posteriori_tester: mesh_testing.APosterioriMeshTester,
+        a_posteriori_tester: mesh_testing.IntersectionTester,
     ) -> None:
         """Initializes self.
 
@@ -143,6 +143,10 @@ class _MeshHandler:
         # setup from config
         self.volume_change = float(self.config.get("MeshQuality", "volume_change"))
         self.angle_change = float(self.config.get("MeshQuality", "angle_change"))
+
+        self.test_for_intersections = self.config.getboolean(
+            "ShapeGradient", "test_for_intersections"
+        )
 
         self.mesh_quality_tol_lower: float = self.config.getfloat(
             "MeshQuality", "tol_lower"
@@ -298,7 +302,9 @@ class _MeshHandler:
             return False
         else:
             success_flag = self.deformation_handler.move_mesh(
-                transformation, validated_a_priori=True
+                transformation,
+                validated_a_priori=True,
+                test_for_intersections=self.test_for_intersections,
             )
             self.current_mesh_quality = quality.compute_mesh_quality(
                 self.mesh, self.mesh_quality_type, self.mesh_quality_measure

--- a/cashocs/geometry/mesh_testing.py
+++ b/cashocs/geometry/mesh_testing.py
@@ -107,7 +107,7 @@ class APrioriMeshTester:
         return bool((min_det >= 1 / volume_change) and (max_det <= volume_change))
 
 
-class APosterioriMeshTester:
+class IntersectionTester:
     """A class for testing the mesh after it has been modified."""
 
     def __init__(self, mesh: fenics.Mesh) -> None:

--- a/cashocs/io/config.py
+++ b/cashocs/io/config.py
@@ -371,6 +371,9 @@ class Config(ConfigParser):
                 "global_deformation": {
                     "type": "bool",
                 },
+                "test_for_intersections": {
+                    "type": "bool",
+                },
             },
             "Regularization": {
                 "factor_volume": {
@@ -599,6 +602,7 @@ shape_bdry_fix_x = []
 shape_bdry_fix_y = []
 shape_bdry_fix_z = []
 global_deformation = False
+test_for_intersections = True
 
 [Regularization]
 factor_volume = 0.0

--- a/cashocs/space_mapping/shape_optimization.py
+++ b/cashocs/space_mapping/shape_optimization.py
@@ -252,9 +252,9 @@ class ParameterExtraction:
         self.coordinates_initial = coarse_model.coordinates_initial
 
         a_priori_tester = mesh_testing.APrioriMeshTester(self.mesh)
-        a_posteriori_tester = mesh_testing.APosterioriMeshTester(self.mesh)
+        intersection_tester = mesh_testing.IntersectionTester(self.mesh)
         self.deformation_handler = geometry.DeformationHandler(
-            self.mesh, a_priori_tester, a_posteriori_tester
+            self.mesh, a_priori_tester, intersection_tester
         )
 
         self.shape_optimization_problem: Optional[sop.ShapeOptimizationProblem] = None
@@ -368,15 +368,15 @@ class SpaceMappingProblem:
 
         self.deformation_space = fenics.VectorFunctionSpace(self.x, "CG", 1)
         a_priori_tester = mesh_testing.APrioriMeshTester(self.fine_model.mesh)
-        a_posteriori_tester = mesh_testing.APosterioriMeshTester(self.fine_model.mesh)
+        intersection_tester = mesh_testing.IntersectionTester(self.fine_model.mesh)
         self.deformation_handler_fine = geometry.DeformationHandler(
-            self.fine_model.mesh, a_priori_tester, a_posteriori_tester
+            self.fine_model.mesh, a_priori_tester, intersection_tester
         )
 
         a_priori_tester = mesh_testing.APrioriMeshTester(self.coarse_model.mesh)
-        a_posteriori_tester = mesh_testing.APosterioriMeshTester(self.coarse_model.mesh)
+        intersection_tester = mesh_testing.IntersectionTester(self.coarse_model.mesh)
         self.deformation_handler_coarse = geometry.DeformationHandler(
-            self.coarse_model.mesh, a_priori_tester, a_posteriori_tester
+            self.coarse_model.mesh, a_priori_tester, intersection_tester
         )
 
         self.z_star = [fenics.Function(self.deformation_space)]

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -310,9 +310,9 @@ def test_convert_coordinate_defo_to_dof_defo():
     mesh, _, _, _, _, _ = cashocs.regular_mesh(20)
     coordinates_initial = mesh.coordinates().copy()
     a_priori_tester = cashocs.geometry.mesh_testing.APrioriMeshTester(mesh)
-    a_posteriori_tester = cashocs.geometry.mesh_testing.APosterioriMeshTester(mesh)
+    intersection_tester = cashocs.geometry.mesh_testing.IntersectionTester(mesh)
     deformation_handler = cashocs.DeformationHandler(
-        mesh, a_priori_tester, a_posteriori_tester
+        mesh, a_priori_tester, intersection_tester
     )
     VCG = fenics.VectorFunctionSpace(mesh, "CG", 1)
     coordinate_deformation = (
@@ -333,9 +333,9 @@ def test_convert_dof_defo_to_coordinate_defo(rng):
     mesh, _, _, _, _, _ = cashocs.regular_mesh(20)
     coordinates_initial = mesh.coordinates().copy()
     a_priori_tester = cashocs.geometry.mesh_testing.APrioriMeshTester(mesh)
-    a_posteriori_tester = cashocs.geometry.mesh_testing.APosterioriMeshTester(mesh)
+    intersection_tester = cashocs.geometry.mesh_testing.IntersectionTester(mesh)
     deformation_handler = cashocs.DeformationHandler(
-        mesh, a_priori_tester, a_posteriori_tester
+        mesh, a_priori_tester, intersection_tester
     )
     VCG = fenics.VectorFunctionSpace(mesh, "CG", 1)
     defo = fenics.Function(VCG)
@@ -356,9 +356,9 @@ def test_move_mesh():
     mesh, _, _, _, _, _ = cashocs.regular_mesh(20)
     coordinates_initial = mesh.coordinates().copy()
     a_priori_tester = cashocs.geometry.mesh_testing.APrioriMeshTester(mesh)
-    a_posteriori_tester = cashocs.geometry.mesh_testing.APosterioriMeshTester(mesh)
+    intersection_tester = cashocs.geometry.mesh_testing.IntersectionTester(mesh)
     deformation_handler = cashocs.DeformationHandler(
-        mesh, a_priori_tester, a_posteriori_tester
+        mesh, a_priori_tester, intersection_tester
     )
 
     coordinate_deformation = coordinates_initial.copy()


### PR DESCRIPTION
The intersection test can be skipped with this parameter.