### PR TITLE
CI: Improve and update GitHub actions workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,9 +23,9 @@ jobs:
         run: |
           if [[ ${GITHUB_REF#refs/tags/} == v* ]]
           then
-            echo "::set-output name=TAG_PREFIX::${GITHUB_REF#refs/tags/}"
+            echo "TAG_PREFIX=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=TAG_PREFIX::latest"
+            echo "TAG_PREFIX=latest" >> $GITHUB_OUTPUT
           fi
 
       - name: Log into the Dockerhub registry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,8 @@ jobs:
   build_and_publish:
     name: Build and publish python package
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     needs:
       - run_tests
 
@@ -93,6 +95,3 @@ jobs:
 
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Get tag name
       id: tag_name
       run: |
-        echo "::set-output name=TAG_PREFIX::${GITHUB_REF#refs/tags/}"
+        echo "TAG_PREFIX=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
 
     - name: Check if release is a pre-release


### PR DESCRIPTION
This PR adds two changes:
- It adds trusted publishing for PyPI in the publish.yml workflow
- It upgrades some actions to use environment files instead of the deprecated "set-output" command