### PR TITLE
FEAT: Add the kwargs `linear_solver` and `adjoint_linear_solver`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ of the maintenance releases, please take a look at
 
 * :py:func:`cashocs.import_mesh` can now also directly import a Gmsh mesh file. Internally, the mesh is directly converted to xdmf and then read. At the moment, this only supports the conversion mode `physical`.
 
+* Add the kwargs `linear_solver` and (where applicable) `adjoint_linear_solver`. These can be used to define custom python KSP objects via petsc4py, most importantly, custom python-based preconditioners can be used with these. The feature is covered in the undocumented demo "demos/shape_optimization/python_pc".
+
 * New configuration file parameters:
 
   * Section LineSearch

--- a/cashocs/_forms/shape_regularization.py
+++ b/cashocs/_forms/shape_regularization.py
@@ -551,6 +551,7 @@ class CurvatureRegularization(ShapeRegularizationTerm):
         if self.mu > 0:
             self.is_active = True
 
+        self.linear_solver = _utils.linalg.LinearSolver(self.db.geometry_db.mpi_comm)
         self.scale()
 
     def compute_shape_derivative(self) -> ufl.Form:
@@ -612,11 +613,10 @@ class CurvatureRegularization(ShapeRegularizationTerm):
 
         fenics.assemble(self.l_curvature, tensor=self.b_curvature)
 
-        _utils.solve_linear_problem(
+        self.linear_solver.solve(
             A=self.a_curvature_matrix.mat(),
             b=self.b_curvature.vec(),
             fun=self.kappa_curvature,
-            comm=self.db.geometry_db.mpi_comm,
         )
 
     def scale(self) -> None:

--- a/cashocs/_optimization/optimal_control/optimal_control_problem.py
+++ b/cashocs/_optimization/optimal_control/optimal_control_problem.py
@@ -93,6 +93,7 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
         preconditioner_forms: Optional[Union[List[ufl.Form], ufl.Form]] = None,
         pre_callback: Optional[Callable] = None,
         post_callback: Optional[Callable] = None,
+        linear_solver: Optional[_utils.linalg.LinearSolver] = None,
     ) -> None:
         r"""Initializes self.
 
@@ -152,6 +153,8 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
                 solve of the state system
             post_callback: A function (without arguments) that will be called after the
                 computation of the gradient.
+            linear_solver: The linear solver (KSP) which is used to solve the linear
+                systems arising from the discretized PDE.
 
         Examples:
             Examples how to use this class can be found in the :ref:`tutorial
@@ -173,6 +176,7 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
             preconditioner_forms=preconditioner_forms,
             pre_callback=pre_callback,
             post_callback=post_callback,
+            linear_solver=linear_solver,
         )
 
         self.db.function_db.controls = _utils.enlist(controls)

--- a/cashocs/_optimization/optimal_control/optimal_control_problem.py
+++ b/cashocs/_optimization/optimal_control/optimal_control_problem.py
@@ -94,6 +94,7 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
         pre_callback: Optional[Callable] = None,
         post_callback: Optional[Callable] = None,
         linear_solver: Optional[_utils.linalg.LinearSolver] = None,
+        adjoint_linear_solver: Optional[_utils.linalg.LinearSolver] = None,
     ) -> None:
         r"""Initializes self.
 
@@ -155,6 +156,8 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
                 computation of the gradient.
             linear_solver: The linear solver (KSP) which is used to solve the linear
                 systems arising from the discretized PDE.
+            adjoint_linear_solver: The linear solver (KSP) which is used to solve the
+                (linear) adjoint system.
 
         Examples:
             Examples how to use this class can be found in the :ref:`tutorial
@@ -177,6 +180,7 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
             pre_callback=pre_callback,
             post_callback=post_callback,
             linear_solver=linear_solver,
+            adjoint_linear_solver=adjoint_linear_solver,
         )
 
         self.db.function_db.controls = _utils.enlist(controls)

--- a/cashocs/_optimization/optimization_problem.py
+++ b/cashocs/_optimization/optimization_problem.py
@@ -116,6 +116,7 @@ class OptimizationProblem(abc.ABC):
             Union[Callable[[], None], Callable[[_typing.OptimizationProblem], None]]
         ] = None,
         linear_solver: Optional[_utils.linalg.LinearSolver] = None,
+        adjoint_linear_solver: Optional[_utils.linalg.LinearSolver] = None,
     ) -> None:
         r"""Initializes self.
 
@@ -172,6 +173,8 @@ class OptimizationProblem(abc.ABC):
                 computation of the gradient.
             linear_solver: The linear solver (KSP) which is used to solve the linear
                 systems arising from the discretized PDE.
+            adjoint_linear_solver: The linear solver (KSP) which is used to solve the
+                (linear) adjoint system.
 
         Notes:
             If one uses a single PDE constraint, the inputs can be the objects
@@ -240,6 +243,7 @@ class OptimizationProblem(abc.ABC):
         )
 
         self.linear_solver = linear_solver
+        self.adjoint_linear_solver = adjoint_linear_solver
 
         self.db.callback.pre_callback = pre_callback
         self.db.callback.post_callback = post_callback
@@ -260,7 +264,7 @@ class OptimizationProblem(abc.ABC):
             self.db,
             self.general_form_handler.adjoint_form_handler,
             self.state_problem,
-            linear_solver=self.linear_solver,
+            linear_solver=self.adjoint_linear_solver,
         )
         self.output_manager = io.OutputManager(self.db)
 

--- a/cashocs/_optimization/optimization_problem.py
+++ b/cashocs/_optimization/optimization_problem.py
@@ -115,6 +115,7 @@ class OptimizationProblem(abc.ABC):
         post_callback: Optional[
             Union[Callable[[], None], Callable[[_typing.OptimizationProblem], None]]
         ] = None,
+        linear_solver: Optional[_utils.linalg.LinearSolver] = None,
     ) -> None:
         r"""Initializes self.
 
@@ -169,6 +170,8 @@ class OptimizationProblem(abc.ABC):
                 solve of the state system
             post_callback: A function (without arguments) that will be called after the
                 computation of the gradient.
+            linear_solver: The linear solver (KSP) which is used to solve the linear
+                systems arising from the discretized PDE.
 
         Notes:
             If one uses a single PDE constraint, the inputs can be the objects
@@ -236,6 +239,8 @@ class OptimizationProblem(abc.ABC):
             self.preconditioner_forms,
         )
 
+        self.linear_solver = linear_solver
+
         self.db.callback.pre_callback = pre_callback
         self.db.callback.post_callback = post_callback
         self.db.callback.problem = weakref.proxy(self)
@@ -249,11 +254,13 @@ class OptimizationProblem(abc.ABC):
             self.db,
             self.general_form_handler.state_form_handler,
             self.initial_guess,
+            linear_solver=self.linear_solver,
         )
         self.adjoint_problem = _pde_problems.AdjointProblem(
             self.db,
             self.general_form_handler.adjoint_form_handler,
             self.state_problem,
+            linear_solver=self.linear_solver,
         )
         self.output_manager = io.OutputManager(self.db)
 

--- a/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
+++ b/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
@@ -99,6 +99,7 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
         pre_callback: Optional[Callable] = None,
         post_callback: Optional[Callable] = None,
         linear_solver: Optional[_utils.linalg.LinearSolver] = None,
+        adjoint_linear_solver: Optional[_utils.linalg.LinearSolver] = None,
     ) -> None:
         """Initializes self.
 
@@ -163,6 +164,8 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
                 computation of the gradient.
             linear_solver: The linear solver (KSP) which is used to solve the linear
                 systems arising from the discretized PDE.
+            adjoint_linear_solver: The linear solver (KSP) which is used to solve the
+                (linear) adjoint system.
 
         """
         super().__init__(
@@ -183,6 +186,7 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
             pre_callback=pre_callback,
             post_callback=post_callback,
             linear_solver=linear_solver,
+            adjoint_linear_solver=adjoint_linear_solver,
         )
 
         if shape_scalar_product is None:

--- a/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
+++ b/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
@@ -36,6 +36,7 @@ from cashocs import _exceptions
 from cashocs import _forms
 from cashocs import _loggers
 from cashocs import _pde_problems
+from cashocs import _utils
 from cashocs import geometry
 from cashocs import io
 from cashocs._optimization import cost_functional
@@ -97,6 +98,7 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
         preconditioner_forms: Optional[Union[List[ufl.Form], ufl.Form]] = None,
         pre_callback: Optional[Callable] = None,
         post_callback: Optional[Callable] = None,
+        linear_solver: Optional[_utils.linalg.LinearSolver] = None,
     ) -> None:
         """Initializes self.
 
@@ -159,6 +161,8 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
                 solve of the state system
             post_callback: A function (without arguments) that will be called after the
                 computation of the gradient.
+            linear_solver: The linear solver (KSP) which is used to solve the linear
+                systems arising from the discretized PDE.
 
         """
         super().__init__(
@@ -178,6 +182,7 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
             preconditioner_forms=preconditioner_forms,
             pre_callback=pre_callback,
             post_callback=post_callback,
+            linear_solver=linear_solver,
         )
 
         if shape_scalar_product is None:

--- a/cashocs/_optimization/topology_optimization/topology_optimization_algorithm.py
+++ b/cashocs/_optimization/topology_optimization/topology_optimization_algorithm.py
@@ -99,6 +99,8 @@ class TopologyOptimizationAlgorithm(optimization_algorithms.OptimizationAlgorith
         self.levelset_function_prev = fenics.Function(self.cg1_space)
         self.setup_assembler()
 
+        self.linear_solver = _utils.linalg.LinearSolver(self.db.geometry_db.mpi_comm)
+
     def _generate_measure(self) -> fenics.Measure:
         """Generates the measure for projecting the topological derivative.
 
@@ -263,7 +265,7 @@ class TopologyOptimizationAlgorithm(optimization_algorithms.OptimizationAlgorith
             _pde_problems.ControlGradientProblem, self.gradient_problem
         )
         self.assembler.assemble(self.b_tensor)
-        _utils.solve_linear_problem(
+        self.linear_solver.solve(
             A=self.riesz_matrix,
             b=self.b_tensor.vec(),
             fun=self.topological_derivative_vertex,

--- a/cashocs/_optimization/topology_optimization/topology_optimization_problem.py
+++ b/cashocs/_optimization/topology_optimization/topology_optimization_problem.py
@@ -90,6 +90,7 @@ class TopologyOptimizationProblem(_optimization.OptimizationProblem):
         pre_callback: Optional[Callable] = None,
         post_callback: Optional[Callable] = None,
         linear_solver: Optional[_utils.linalg.LinearSolver] = None,
+        adjoint_linear_solver: Optional[_utils.linalg.LinearSolver] = None,
     ) -> None:
         r"""Initializes the topology optimization problem.
 
@@ -151,6 +152,8 @@ class TopologyOptimizationProblem(_optimization.OptimizationProblem):
                 computation of the gradient.
             linear_solver: The linear solver (KSP) which is used to solve the linear
                 systems arising from the discretized PDE.
+            adjoint_linear_solver: The linear solver (KSP) which is used to solve the
+                (linear) adjoint system.
 
         """
         super().__init__(
@@ -169,6 +172,7 @@ class TopologyOptimizationProblem(_optimization.OptimizationProblem):
             pre_callback=pre_callback,
             post_callback=post_callback,
             linear_solver=linear_solver,
+            adjoint_linear_solver=adjoint_linear_solver,
         )
 
         self.db.parameter_db.problem_type = "topology"

--- a/cashocs/_optimization/topology_optimization/topology_optimization_problem.py
+++ b/cashocs/_optimization/topology_optimization/topology_optimization_problem.py
@@ -33,6 +33,7 @@ except ImportError:
 
 from cashocs import _exceptions
 from cashocs import _optimization
+from cashocs import _utils
 from cashocs import io
 from cashocs._optimization import line_search as ls
 from cashocs._optimization.optimal_control import optimal_control_problem
@@ -88,6 +89,7 @@ class TopologyOptimizationProblem(_optimization.OptimizationProblem):
         preconditioner_forms: Optional[Union[List[ufl.Form], ufl.Form]] = None,
         pre_callback: Optional[Callable] = None,
         post_callback: Optional[Callable] = None,
+        linear_solver: Optional[_utils.linalg.LinearSolver] = None,
     ) -> None:
         r"""Initializes the topology optimization problem.
 
@@ -147,6 +149,8 @@ class TopologyOptimizationProblem(_optimization.OptimizationProblem):
                 solve of the state system
             post_callback: A function (without arguments) that will be called after the
                 computation of the gradient.
+            linear_solver: The linear solver (KSP) which is used to solve the linear
+                systems arising from the discretized PDE.
 
         """
         super().__init__(
@@ -164,6 +168,7 @@ class TopologyOptimizationProblem(_optimization.OptimizationProblem):
             preconditioner_forms=preconditioner_forms,
             pre_callback=pre_callback,
             post_callback=post_callback,
+            linear_solver=linear_solver,
         )
 
         self.db.parameter_db.problem_type = "topology"
@@ -221,6 +226,7 @@ class TopologyOptimizationProblem(_optimization.OptimizationProblem):
             ksp_options=ksp_options,
             adjoint_ksp_options=adjoint_ksp_options,
             desired_weights=desired_weights,
+            linear_solver=linear_solver,
         )
         self._base_ocp.db.parameter_db.problem_type = "topology"
         self.db.function_db.control_spaces = (

--- a/cashocs/_pde_problems/adjoint_problem.py
+++ b/cashocs/_pde_problems/adjoint_problem.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import List, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING
 
 import fenics
 
@@ -41,6 +41,7 @@ class AdjointProblem(pde_problem.PDEProblem):
         db: database.Database,
         adjoint_form_handler: _forms.AdjointFormHandler,
         state_problem: sp.StateProblem,
+        linear_solver: Optional[_utils.linalg.LinearSolver] = None,
     ) -> None:
         """Initializes self.
 
@@ -49,9 +50,11 @@ class AdjointProblem(pde_problem.PDEProblem):
             adjoint_form_handler: The form handler for the adjoint system.
             state_problem: The StateProblem object used to get the point where we
                 linearize the problem.
+            linear_solver: The linear solver (KSP) which is used to solve the linear
+                systems arising from the discretized PDE.
 
         """
-        super().__init__(db)
+        super().__init__(db, linear_solver=linear_solver)
 
         self.adjoint_form_handler = adjoint_form_handler
         self.state_problem = state_problem
@@ -126,6 +129,7 @@ class AdjointProblem(pde_problem.PDEProblem):
                         preconditioner_form=self.db.form_db.preconditioner_forms[
                             -1 - i
                         ],
+                        linear_solver=self.linear_solver,
                     )
 
             else:
@@ -146,6 +150,7 @@ class AdjointProblem(pde_problem.PDEProblem):
                     b_tensors=self.b_tensors[::-1],
                     inner_is_linear=True,
                     preconditioner_forms=self.db.form_db.preconditioner_forms[::-1],
+                    linear_solver=self.linear_solver,
                 )
 
             self.has_solution = True

--- a/cashocs/_pde_problems/control_gradient_problem.py
+++ b/cashocs/_pde_problems/control_gradient_problem.py
@@ -104,12 +104,11 @@ class ControlGradientProblem(pde_problem.PDEProblem):
         if not self.has_solution:
             for i in range(len(self.db.function_db.gradient)):
                 self.form_handler.assemblers[i].assemble(self.b_tensors[i])
-                _utils.solve_linear_problem(
+                self.linear_solver.solve(
                     A=self.form_handler.riesz_projection_matrices[i],
                     b=self.b_tensors[i].vec(),
                     fun=self.db.function_db.gradient[i],
                     ksp_options=self.riesz_ksp_options[i],
-                    comm=self.db.geometry_db.mpi_comm,
                 )
 
             self.has_solution = True

--- a/cashocs/_pde_problems/hessian_problems.py
+++ b/cashocs/_pde_problems/hessian_problems.py
@@ -140,6 +140,8 @@ class HessianProblem:
         for _ in range(len(self.db.function_db.controls)):
             self.riesz_ksp_options.append(option)
 
+        self.linear_solver = _utils.linalg.LinearSolver(self.db.geometry_db.mpi_comm)
+
     def hessian_application(
         self, h: List[fenics.Function], out: List[fenics.Function]
     ) -> None:
@@ -234,12 +236,11 @@ class HessianProblem:
                 fenics.assemble(self.form_handler.hessian_form_handler.hessian_rhs[i])
             ).vec()
 
-            _utils.solve_linear_problem(
+            self.linear_solver.solve(
                 A=self.form_handler.riesz_projection_matrices[i],
                 b=b,
                 fun=out[i],
                 ksp_options=self.riesz_ksp_options[i],
-                comm=self.db.geometry_db.mpi_comm,
             )
 
         self.no_sensitivity_solves += 2

--- a/cashocs/_pde_problems/pde_problem.py
+++ b/cashocs/_pde_problems/pde_problem.py
@@ -20,9 +20,11 @@
 from __future__ import annotations
 
 import abc
-from typing import List, TYPE_CHECKING, Union
+from typing import List, Optional, TYPE_CHECKING, Union
 
 import fenics
+
+from cashocs import _utils
 
 if TYPE_CHECKING:
     from cashocs._database import database
@@ -31,17 +33,29 @@ if TYPE_CHECKING:
 class PDEProblem(abc.ABC):
     """Base class for a PDE problem."""
 
-    def __init__(self, db: database.Database) -> None:
+    def __init__(
+        self,
+        db: database.Database,
+        linear_solver: Optional[_utils.linalg.LinearSolver] = None,
+    ) -> None:
         """Initializes self.
 
         Args:
             db: The database of the problem
+            linear_solver: The linear solver (KSP) which is used to solve the linear
+                systems arising from the discretized PDE
 
         """
         self.db = db
 
         self.config = db.config
-        self.has_solution = False
+        self.has_solution: bool = False
+        if linear_solver is None:
+            self.linear_solver = _utils.linalg.LinearSolver(
+                comm=self.db.geometry_db.mpi_comm
+            )
+        else:
+            self.linear_solver = linear_solver
 
     @abc.abstractmethod
     def solve(self) -> Union[fenics.Function, List[fenics.Function]]:

--- a/cashocs/_pde_problems/shape_gradient_problem.py
+++ b/cashocs/_pde_problems/shape_gradient_problem.py
@@ -143,12 +143,11 @@ class ShapeGradientProblem(pde_problem.PDEProblem):
                         np.array([0.0] * len(self.form_handler.fixed_indices)),
                     )
                     self.form_handler.fe_shape_derivative_vector.apply("")
-                _utils.solve_linear_problem(
+                self.linear_solver.solve(
                     A=self.form_handler.scalar_product_matrix,
                     b=self.form_handler.fe_shape_derivative_vector.vec(),
                     fun=self.db.function_db.gradient[0],
                     ksp_options=self.ksp_options,
-                    comm=self.db.geometry_db.mpi_comm,
                 )
 
                 self.has_solution = True

--- a/cashocs/_pde_problems/state_problem.py
+++ b/cashocs/_pde_problems/state_problem.py
@@ -40,6 +40,7 @@ class StateProblem(pde_problem.PDEProblem):
         db: database.Database,
         state_form_handler: _forms.StateFormHandler,
         initial_guess: Optional[List[fenics.Function]],
+        linear_solver: Optional[_utils.linalg.LinearSolver] = None,
     ) -> None:
         """Initializes self.
 
@@ -48,9 +49,11 @@ class StateProblem(pde_problem.PDEProblem):
             state_form_handler: The form handler for the state problem.
             initial_guess: An initial guess for the state variables, used to initialize
                 them in each iteration.
+            linear_solver: The linear solver (KSP) which is used to solve the linear
+                systems arising from the discretized PDE.
 
         """
-        super().__init__(db)
+        super().__init__(db, linear_solver=linear_solver)
 
         self.state_form_handler = state_form_handler
         self.initial_guess = initial_guess
@@ -129,6 +132,7 @@ class StateProblem(pde_problem.PDEProblem):
                             ksp_options=self.db.parameter_db.state_ksp_options[i],
                             comm=self.db.geometry_db.mpi_comm,
                             preconditioner_form=self.db.form_db.preconditioner_forms[i],
+                            linear_solver=self.linear_solver,
                         )
 
                 else:
@@ -149,6 +153,7 @@ class StateProblem(pde_problem.PDEProblem):
                             A_tensor=self.A_tensors[i],
                             b_tensor=self.b_tensors[i],
                             preconditioner_form=self.db.form_db.preconditioner_forms[i],
+                            linear_solver=self.linear_solver,
                         )
 
             else:
@@ -169,6 +174,7 @@ class StateProblem(pde_problem.PDEProblem):
                     b_tensors=self.b_tensors,
                     inner_is_linear=self.config.getboolean("StateSystem", "is_linear"),
                     preconditioner_forms=self.db.form_db.preconditioner_forms,
+                    linear_solver=self.linear_solver,
                 )
 
             self.has_solution = True

--- a/cashocs/nonlinear_solvers/linear_solver.py
+++ b/cashocs/nonlinear_solvers/linear_solver.py
@@ -95,8 +95,7 @@ def linear_solve(
     else:
         P_matrix = None  # pylint: disable=invalid-name
 
-    _utils.solve_linear_problem(
-        A=A_matrix, b=b, fun=u, ksp_options=ksp_options, comm=comm, P=P_matrix
-    )
+    linear_solver = _utils.linalg.LinearSolver(comm)
+    linear_solver.solve(A=A_matrix, b=b, fun=u, ksp_options=ksp_options, P=P_matrix)
 
     return u

--- a/cashocs/nonlinear_solvers/linear_solver.py
+++ b/cashocs/nonlinear_solvers/linear_solver.py
@@ -43,6 +43,7 @@ def linear_solve(
     preconditioner_form: ufl.Form = None,
     A_tensor: Optional[fenics.PETScMatrix] = None,  # pylint: disable=invalid-name
     b_tensor: Optional[fenics.PETScVector] = None,
+    linear_solver: Optional[_utils.linalg.LinearSolver] = None,
 ) -> fenics.Function:
     """Solves a linear problem.
 
@@ -56,6 +57,7 @@ def linear_solve(
             sub-problem.
         b_tensor: A fenics.PETScVector for storing the right-hand side of the linear
             sub-problem.
+        linear_solver: The linear solver used to solve the (discretized) linear problem.
 
     Returns:
         The computed solution, this overwrites the input function `u`.
@@ -95,7 +97,8 @@ def linear_solve(
     else:
         P_matrix = None  # pylint: disable=invalid-name
 
-    linear_solver = _utils.linalg.LinearSolver(comm)
+    if linear_solver is None:
+        linear_solver = _utils.linalg.LinearSolver(comm)
     linear_solver.solve(A=A_matrix, b=b, fun=u, ksp_options=ksp_options, P=P_matrix)
 
     return u

--- a/cashocs/nonlinear_solvers/newton_solver.py
+++ b/cashocs/nonlinear_solvers/newton_solver.py
@@ -60,7 +60,8 @@ class _NewtonSolver:
         A_tensor: Optional[fenics.PETScMatrix] = None,  # pylint: disable=invalid-name
         b_tensor: Optional[fenics.PETScVector] = None,
         is_linear: bool = False,
-        preconditioner_form: ufl.Form = None,
+        preconditioner_form: Optional[ufl.Form] = None,
+        linear_solver: Optional[_utils.linalg.LinearSolver] = None,
     ) -> None:
         r"""Initializes self.
 
@@ -99,6 +100,8 @@ class _NewtonSolver:
             is_linear: A boolean flag, which indicates whether the problem is actually
                 linear.
             preconditioner_form: A UFL form which defines the preconditioner matrix.
+            linear_solver: The linear solver (KSP) which is used to solve the linear
+                systems arising from the discretized PDE
 
         """
         self.nonlinear_form = nonlinear_form
@@ -173,6 +176,11 @@ class _NewtonSolver:
         self.A_matrix = fenics.as_backend_type(self.A_fenics).mat()
 
         self.P_fenics = fenics.PETScMatrix(self.comm)
+
+        if linear_solver is None:
+            self.linear_solver = _utils.linalg.LinearSolver(self.comm)
+        else:
+            self.linear_solver = linear_solver
 
         self.assembler_shift: Optional[fenics.SystemAssembler] = None
         self.residual_shift: Optional[fenics.PETScVector] = None
@@ -288,14 +296,13 @@ class _NewtonSolver:
             self.u_save.vector().apply("")
 
             self._compute_eta_inexact()
-            _utils.solve_linear_problem(
+            self.linear_solver.solve(
                 A=self.A_matrix,
                 b=self.b,
                 fun=self.du,
                 ksp_options=self.ksp_options,
                 rtol=self.eta,
                 atol=self.atol / 10.0,
-                comm=self.comm,
                 P=self.P_matrix,
             )
 
@@ -395,14 +402,13 @@ class _NewtonSolver:
                 self.u.vector().vec().axpy(self.lmbd, self.du.vector().vec())
                 self.u.vector().apply("")
                 self._compute_residual()
-                _utils.solve_linear_problem(
+                self.linear_solver.solve(
                     A=self.A_matrix,
                     b=self.b,
                     fun=self.ddu,
                     ksp_options=self.ksp_options,
                     rtol=self.eta,
                     atol=self.atol / 10.0,
-                    comm=self.comm,
                     P=self.P_matrix,
                 )
 
@@ -443,7 +449,8 @@ def newton_solve(
     A_tensor: Optional[fenics.PETScMatrix] = None,  # pylint: disable=invalid-name
     b_tensor: Optional[fenics.PETScVector] = None,
     is_linear: bool = False,
-    preconditioner_form: ufl.Form = None,
+    preconditioner_form: Optional[ufl.Form] = None,
+    linear_solver: Optional[_utils.linalg.LinearSolver] = None,
 ) -> fenics.Function:
     r"""Solves a nonlinear problem with Newton\'s method.
 
@@ -479,6 +486,9 @@ def newton_solve(
             sub-problem.
         is_linear: A boolean flag, which indicates whether the problem is actually
             linear.
+        preconditioner_form: A UFL form which defines the preconditioner matrix.
+        linear_solver: The linear solver (KSP) which is used to solve the linear
+            systems arising from the discretized PDE.
 
     Returns:
         The solution of the nonlinear variational problem, if converged. This overwrites
@@ -527,6 +537,7 @@ def newton_solve(
         b_tensor=b_tensor,
         is_linear=is_linear,
         preconditioner_form=preconditioner_form,
+        linear_solver=linear_solver,
     )
 
     solution = solver.solve()

--- a/cashocs/nonlinear_solvers/picard_solver.py
+++ b/cashocs/nonlinear_solvers/picard_solver.py
@@ -98,6 +98,7 @@ def picard_iteration(
     b_tensors: Optional[List[fenics.PETScVector]] = None,
     inner_is_linear: bool = False,
     preconditioner_forms: Optional[Union[List[ufl.Form], ufl.Form]] = None,
+    linear_solver: Optional[_utils.linalg.LinearSolver] = None,
 ) -> None:
     """Solves a system of coupled PDEs via a Picard iteration.
 
@@ -126,8 +127,10 @@ def picard_iteration(
         inner_is_linear: Boolean flag, if this is ``True``, all problems are actually
             linear ones, and only a linear solver is used.
         preconditioner_forms: The list of forms for the preconditioner. The default
-                is `None`, so that the preconditioner matrix is the same as the system
-                matrix.
+            is `None`, so that the preconditioner matrix is the same as the system
+            matrix.
+        linear_solver: The linear solver (KSP) which is used to solve the linear
+            systems arising from the discretized PDE.
 
     """
     is_printing = verbose and fenics.MPI.rank(fenics.MPI.comm_world) == 0
@@ -192,6 +195,7 @@ def picard_iteration(
                 b_tensor=b_tensor,
                 is_linear=inner_is_linear,
                 preconditioner_form=preconditioner_form_list[j],
+                linear_solver=linear_solver,
             )
 
     if is_printing:

--- a/demos/undocumented/shape_optimization/python_pc/python_pc.py
+++ b/demos/undocumented/shape_optimization/python_pc/python_pc.py
@@ -1,0 +1,109 @@
+# Copyright (C) 2020-2024 Sebastian Blauth
+#
+# This file is part of cashocs.
+#
+# cashocs is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cashocs is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cashocs.  If not, see <https://www.gnu.org/licenses/>.
+
+from fenics import *
+from petsc4py import PETSc
+
+import cashocs
+
+mesh, subdomains, boundaries, dx, ds, dS = cashocs.regular_mesh(16)
+V = FunctionSpace(mesh, "CG", 1)
+
+u = Function(V)
+v = TestFunction(V)
+
+F = dot(grad(u), grad(v)) * dx - Constant(1.0) * v * dx
+
+bcs = cashocs.create_dirichlet_bcs(V, Constant(0.0), boundaries, [1, 2, 3, 4])
+
+ksp_options = {
+    "ksp_type": "cg",
+    "pc_type": "jacobi",
+    "ksp_monitor_true_residual": None,
+    "ksp_view": None,
+}
+# Solve with default petsc PC and show KSP monitor
+cashocs.linear_solve(F, u, bcs, ksp_options=ksp_options)
+
+# reset u
+u.vector().vec().set(0.0)
+u.vector().apply("")
+
+
+# Use the example Jacobi PC from petsc4py
+class JacobiPC:
+    # Setup the internal data. In this case, we access the matrix diagonal.
+    def setUp(self, pc):
+        _, P = pc.getOperators()
+        self.D = P.getDiagonal()
+
+    # Apply the preconditioner
+    def apply(self, pc, x, y):
+        y.pointwiseDivide(x, self.D)
+
+
+# Setup the custom linear solver with python PC
+class MyLinearSolver(cashocs._utils.linalg.LinearSolver):
+    def __init__(self, comm):
+        super().__init__(comm)
+
+    def solve(self, A, b, fun=None, ksp_options=None, rtol=None, atol=None, P=None):
+        ksp = PETSc.KSP().create(self.comm)
+        pc = ksp.getPC()
+        pc.setType(PETSc.PC.Type.PYTHON)
+        pc.setPythonContext(JacobiPC())
+
+        if P is None:
+            ksp.setOperators(A)
+        else:
+            ksp.setOperators(A, P)
+
+        if fun is None:
+            x, _ = A.getVecs()
+        else:
+            x = fun.vector().vec()
+
+        if ksp_options is not None:
+            cashocs._utils.linalg.setup_petsc_options([ksp], [ksp_options])
+
+        ksp.setFromOptions()
+        if rtol is not None:
+            ksp.rtol = rtol
+        if atol is not None:
+            ksp.atol = atol
+
+        ksp.solve(b, x)
+
+        if ksp.getConvergedReason() < 0:
+            raise Exception(
+                f"PETSc KSP did not converge. Reason: {ksp.getConvergedReason()}"
+            )
+
+        if hasattr(PETSc, "garbage_cleanup"):
+            ksp.destroy()
+            PETSc.garbage_cleanup(comm=self.comm)
+            PETSc.garbage_cleanup()
+
+        if fun is not None:
+            fun.vector().apply("")
+
+        return x
+
+
+ksp_options = {"ksp_type": "cg", "ksp_monitor_true_residual": None, "ksp_view": None}
+my_linear_solver = MyLinearSolver(mesh.mpi_comm())
+cashocs.linear_solve(F, u, bcs, ksp_options=ksp_options, linear_solver=my_linear_solver)


### PR DESCRIPTION
These parameters make it possible to define custom, petsc4py based, linear solvers and, most importantly, preconditioners that are python-based.