### PR TITLE
Prevent upload to codacy action blocking PRs from forks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,7 @@ jobs:
         files: coverage.xml
 
     - name: Upload coverage to codacy
+      continue-on-error: true
       uses: codacy/codacy-coverage-reporter-action@v1
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}


### PR DESCRIPTION
Add continue-on-error: true to the tests.yml config.
See https://github.com/codacy/codacy-coverage-reporter-action/issues/33