### PR TITLE
Add the kwarg `newton_linearization` to the optimization problems

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ of the maintenance releases, please take a look at
 
 * Add the kwargs `linear_solver` and (where applicable) `adjoint_linear_solver`. These can be used to define custom python KSP objects via petsc4py, most importantly, custom python-based preconditioners can be used with these. The feature is covered in the undocumented demo "demos/shape_optimization/python_pc".
 
+* Add the kwarg `newton_linearization` to the optimization problem classes. This can be used to specify which (alternative) linearization techniques can be used for solving the nonlinear state systems.
+
 * New configuration file parameters:
 
   * Section LineSearch

--- a/cashocs/_optimization/optimal_control/optimal_control_problem.py
+++ b/cashocs/_optimization/optimal_control/optimal_control_problem.py
@@ -95,6 +95,7 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
         post_callback: Optional[Callable] = None,
         linear_solver: Optional[_utils.linalg.LinearSolver] = None,
         adjoint_linear_solver: Optional[_utils.linalg.LinearSolver] = None,
+        newton_linearizations: Optional[Union[ufl.Form, List[ufl.Form]]] = None,
     ) -> None:
         r"""Initializes self.
 
@@ -158,6 +159,10 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
                 systems arising from the discretized PDE.
             adjoint_linear_solver: The linear solver (KSP) which is used to solve the
                 (linear) adjoint system.
+            newton_linearizations: A (list of) UFL forms describing which (alternative)
+                linearizations should be used for the (nonlinear) state equations when
+                solving them (with Newton's method). The default is `None`, so that the
+                Jacobian of the supplied state forms is used.
 
         Examples:
             Examples how to use this class can be found in the :ref:`tutorial
@@ -181,6 +186,7 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
             post_callback=post_callback,
             linear_solver=linear_solver,
             adjoint_linear_solver=adjoint_linear_solver,
+            newton_linearizations=newton_linearizations,
         )
 
         self.db.function_db.controls = _utils.enlist(controls)

--- a/cashocs/_optimization/optimization_problem.py
+++ b/cashocs/_optimization/optimization_problem.py
@@ -266,6 +266,7 @@ class OptimizationProblem(abc.ABC):
             self.general_form_handler.state_form_handler,
             self.initial_guess,
             linear_solver=self.linear_solver,
+            newton_linearizations=self.newton_linearizations,
         )
         self.adjoint_problem = _pde_problems.AdjointProblem(
             self.db,
@@ -409,8 +410,8 @@ class OptimizationProblem(abc.ABC):
             parsed_newton_linearizations: List[Optional[ufl.Form]] = []
             for _ in range(self.state_dim):
                 parsed_newton_linearizations.append(None)
-            else:
-                parsed_newton_linearizations = _utils.enlist(newton_linearizations)
+        else:
+            parsed_newton_linearizations = _utils.enlist(newton_linearizations)
 
         return (
             parsed_initial_guess,

--- a/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
+++ b/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
@@ -100,6 +100,7 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
         post_callback: Optional[Callable] = None,
         linear_solver: Optional[_utils.linalg.LinearSolver] = None,
         adjoint_linear_solver: Optional[_utils.linalg.LinearSolver] = None,
+        newton_linearizations: Optional[Union[ufl.Form, List[ufl.Form]]] = None,
     ) -> None:
         """Initializes self.
 
@@ -166,6 +167,10 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
                 systems arising from the discretized PDE.
             adjoint_linear_solver: The linear solver (KSP) which is used to solve the
                 (linear) adjoint system.
+            newton_linearizations: A (list of) UFL forms describing which (alternative)
+                linearizations should be used for the (nonlinear) state equations when
+                solving them (with Newton's method). The default is `None`, so that the
+                Jacobian of the supplied state forms is used.
 
         """
         super().__init__(
@@ -187,6 +192,7 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
             post_callback=post_callback,
             linear_solver=linear_solver,
             adjoint_linear_solver=adjoint_linear_solver,
+            newton_linearizations=newton_linearizations,
         )
 
         if shape_scalar_product is None:

--- a/cashocs/_optimization/topology_optimization/topology_optimization_problem.py
+++ b/cashocs/_optimization/topology_optimization/topology_optimization_problem.py
@@ -93,6 +93,7 @@ class TopologyOptimizationProblem(_optimization.OptimizationProblem):
         post_callback: Optional[Callable] = None,
         linear_solver: Optional[_utils.linalg.LinearSolver] = None,
         adjoint_linear_solver: Optional[_utils.linalg.LinearSolver] = None,
+        newton_linearizations: Optional[Union[ufl.Form, List[ufl.Form]]] = None,
     ) -> None:
         r"""Initializes the topology optimization problem.
 
@@ -156,6 +157,10 @@ class TopologyOptimizationProblem(_optimization.OptimizationProblem):
                 systems arising from the discretized PDE.
             adjoint_linear_solver: The linear solver (KSP) which is used to solve the
                 (linear) adjoint system.
+            newton_linearizations: A (list of) UFL forms describing which (alternative)
+                linearizations should be used for the (nonlinear) state equations when
+                solving them (with Newton's method). The default is `None`, so that the
+                Jacobian of the supplied state forms is used.
 
         """
         super().__init__(
@@ -175,6 +180,7 @@ class TopologyOptimizationProblem(_optimization.OptimizationProblem):
             post_callback=post_callback,
             linear_solver=linear_solver,
             adjoint_linear_solver=adjoint_linear_solver,
+            newton_linearizations=newton_linearizations,
         )
 
         self.db.parameter_db.problem_type = "topology"

--- a/cashocs/_pde_problems/state_problem.py
+++ b/cashocs/_pde_problems/state_problem.py
@@ -28,6 +28,10 @@ from cashocs import nonlinear_solvers
 from cashocs._pde_problems import pde_problem
 
 if TYPE_CHECKING:
+    try:
+        import ufl_legacy as ufl
+    except ImportError:
+        import ufl
     from cashocs import _forms
     from cashocs._database import database
 
@@ -41,6 +45,7 @@ class StateProblem(pde_problem.PDEProblem):
         state_form_handler: _forms.StateFormHandler,
         initial_guess: Optional[List[fenics.Function]],
         linear_solver: Optional[_utils.linalg.LinearSolver] = None,
+        newton_linearizations: Optional[List[Optional[ufl.Form]]] = None,
     ) -> None:
         """Initializes self.
 
@@ -51,12 +56,20 @@ class StateProblem(pde_problem.PDEProblem):
                 them in each iteration.
             linear_solver: The linear solver (KSP) which is used to solve the linear
                 systems arising from the discretized PDE.
+            newton_linearizations: A (list of) UFL forms describing which (alternative)
+                linearizations should be used for the (nonlinear) state equations when
+                solving them (with Newton's method). The default is `None`, so that the
+                Jacobian of the supplied state forms is used.
 
         """
         super().__init__(db, linear_solver=linear_solver)
 
         self.state_form_handler = state_form_handler
         self.initial_guess = initial_guess
+        if newton_linearizations is not None:
+            self.newton_linearizations = newton_linearizations
+        else:
+            self.newton_linearizations = [None] * self.db.parameter_db.state_dim
 
         self.bcs_list: List[List[fenics.DirichletBC]] = self.state_form_handler.bcs_list
         self.states = self.db.function_db.states
@@ -143,6 +156,7 @@ class StateProblem(pde_problem.PDEProblem):
                             self.state_form_handler.state_eq_forms[i],
                             self.states[i],
                             self.bcs_list[i],
+                            derivative=self.newton_linearizations[i],
                             rtol=self.newton_rtol,
                             atol=self.newton_atol,
                             max_iter=self.newton_iter,
@@ -175,6 +189,7 @@ class StateProblem(pde_problem.PDEProblem):
                     inner_is_linear=self.config.getboolean("StateSystem", "is_linear"),
                     preconditioner_forms=self.db.form_db.preconditioner_forms,
                     linear_solver=self.linear_solver,
+                    newton_linearizations=self.newton_linearizations,
                 )
 
             self.has_solution = True

--- a/cashocs/nonlinear_solvers/picard_solver.py
+++ b/cashocs/nonlinear_solvers/picard_solver.py
@@ -99,6 +99,7 @@ def picard_iteration(
     inner_is_linear: bool = False,
     preconditioner_forms: Optional[Union[List[ufl.Form], ufl.Form]] = None,
     linear_solver: Optional[_utils.linalg.LinearSolver] = None,
+    newton_linearizations: Optional[List[ufl.Form]] = None,
 ) -> None:
     """Solves a system of coupled PDEs via a Picard iteration.
 
@@ -131,6 +132,10 @@ def picard_iteration(
             matrix.
         linear_solver: The linear solver (KSP) which is used to solve the linear
             systems arising from the discretized PDE.
+        newton_linearizations: A list of UFL forms describing which (alternative)
+            linearizations should be used for the (nonlinear) equations when
+            solving them (with Newton's method). The default is `None`, so that the
+            Jacobian of the supplied state forms is used.
 
     """
     is_printing = verbose and fenics.MPI.rank(fenics.MPI.comm_world) == 0
@@ -139,6 +144,11 @@ def picard_iteration(
     bcs_list = _utils.check_and_enlist_bcs(bcs_list)
     bcs_list_hom = _create_homogenized_bcs(bcs_list)
     preconditioner_form_list = _utils.enlist(preconditioner_forms)
+
+    if newton_linearizations is None:
+        newton_linearization_list = [None] * len(u_list)
+    else:
+        newton_linearization_list = newton_linearizations
 
     comm = u_list[0].function_space().mesh().mpi_comm()
 
@@ -184,6 +194,7 @@ def picard_iteration(
                 form_list[j],
                 u_list[j],
                 bcs_list[j],
+                derivative=newton_linearization_list[j],
                 rtol=eta,
                 atol=atol * 1e-1,
                 max_iter=inner_max_iter,

--- a/tests/test_nonlinear_solvers.py
+++ b/tests/test_nonlinear_solvers.py
@@ -59,3 +59,51 @@ def test_newton_solver():
     )
 
     assert np.allclose(u.vector()[:], u_fen.vector()[:])
+
+
+def test_newton_linearization(config_sop):
+    config_sop.set("StateSystem", "is_linear", "False")
+    config_sop.set("StateSystem", "newton_verbose", "True")
+
+    mesh, subdomains, boundaries, dx, ds, dS = cashocs.regular_mesh(16)
+    v_elem = VectorElement("CG", mesh.ufl_cell(), 2)
+    p_elem = FiniteElement("CG", mesh.ufl_cell(), 1)
+    V = FunctionSpace(mesh, MixedElement([v_elem, p_elem]))
+
+    up = Function(V)
+    u, p = split(up)
+    vq = Function(V)
+    v, q = split(vq)
+
+    F = (
+        Constant(1e-2) * inner(grad(u), grad(v)) * dx
+        + dot(grad(u) * u, v) * dx
+        - p * div(v) * dx
+        - q * div(u) * dx
+    )
+    bcs = cashocs.create_dirichlet_bcs(V.sub(0), Constant((1.0, 0.0)), boundaries, 1)
+    bcs += cashocs.create_dirichlet_bcs(
+        V.sub(0), Constant((0.0, 0.0)), boundaries, [3, 4]
+    )
+
+    u_, p_ = TrialFunctions(V)
+    v_, q_ = TestFunctions(V)
+    dF = (
+        Constant(1e-2) * inner(grad(u_), grad(v_)) * dx
+        + dot(grad(u_) * u, v_) * dx
+        - p_ * div(v_) * dx
+        - q_ * div(u_) * dx
+    )
+
+    J = cashocs.IntegralFunctional(Constant(0.0) * dx)
+    sop = cashocs.ShapeOptimizationProblem(
+        F,
+        bcs,
+        J,
+        up,
+        vq,
+        boundaries,
+        config=config_sop,
+        newton_linearizations=dF,
+    )
+    sop.compute_state_variables()


### PR DESCRIPTION
This PR makes the `derivative` kwarg of the newton solver available for the optimization methods of cashocs. This means, alternative linearization strategies can be applied when solving nonlinear state systems, e.g., an Oseen iteration for the Navier Stokes equations (see the added test).

Closes #389 