### PR TITLE
Add the possibility to specify the preconditioner form as bilinear form in Newton's method

### DIFF
--- a/cashocs/nonlinear_solvers/newton_solver.py
+++ b/cashocs/nonlinear_solvers/newton_solver.py
@@ -119,9 +119,14 @@ class _NewtonSolver:
         self.b_tensor = b_tensor
         self.is_linear = is_linear
         if preconditioner_form is not None:
-            self.preconditioner_form = fenics.derivative(preconditioner_form, self.u)
+            if len(preconditioner_form.arguments()) == 1:
+                self.preconditioner_form = fenics.derivative(
+                    preconditioner_form, self.u
+                )
+            else:
+                self.preconditioner_form = preconditioner_form
         else:
-            self.preconditioner_form = preconditioner_form
+            self.preconditioner_form = None
 
         self.verbose = verbose if not self.is_linear else False
 


### PR DESCRIPTION
Previously, the specification of the preconditioner form was only possible as nonlinear form, which would then be differentiated to compute the Jacobian. Now, one can specify the bilinear form for the "Jacobian" directly.