### PR TITLE
ENH: Newton's method now uses the user-specified relative tolerance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,8 @@ of the maintenance releases, please take a look at
 
 * Add the kwarg `newton_linearization` to the optimization problem classes. This can be used to specify which (alternative) linearization techniques can be used for solving the nonlinear state systems.
 
+* The function :py:func:`cashocs.newton_solve` does not change the user-specified tolerance (in the ksp_options) anymore, unless the kwarg `inexact=True` is set. This means, that the user can use custom "inexact Newton" schemes (e.g., gain one digit in accuracy) too. The old default was to use the relative tolerance of the nonlinear iteration multiplied with a safety factor (0.1).
+
 * New configuration file parameters:
 
   * Section LineSearch

--- a/cashocs/nonlinear_solvers/newton_solver.py
+++ b/cashocs/nonlinear_solvers/newton_solver.py
@@ -150,7 +150,7 @@ class _NewtonSolver:
         self.iterations = 0
 
         # inexact newton parameters
-        self.eta = 1.0
+        self.eta: float | None = 1.0
         self.eta_max = 0.9999
         self.eta_a = 1.0
         self.gamma = 0.9
@@ -236,26 +236,26 @@ class _NewtonSolver:
 
     def _compute_eta_inexact(self) -> None:
         """Computes the parameter ``eta`` for the inexact Newton method."""
-        if self.inexact:
+        if self.inexact and isinstance(self.eta, float):
             if self.iterations == 1:
-                self.eta = self.eta_max
+                eta_new = self.eta_max
             elif self.gamma * pow(self.eta, 2) <= 0.1:
-                self.eta = np.minimum(self.eta_max, self.eta_a)
+                eta_new = np.minimum(self.eta_max, self.eta_a)
             else:
-                self.eta = np.minimum(
+                eta_new = np.minimum(
                     self.eta_max,
                     np.maximum(self.eta_a, self.gamma * pow(self.eta, 2)),
                 )
 
             self.eta = np.minimum(
                 self.eta_max,
-                np.maximum(self.eta, 0.5 * self.tol / self.res),
+                np.maximum(eta_new, 0.5 * self.tol / self.res),
             )
         else:
-            self.eta = self.rtol * 1e-1
+            self.eta = None
 
         if self.is_linear:
-            self.eta = self.rtol * 1e-1
+            self.eta = None
 
     def _check_for_nan_residual(self) -> None:
         """Checks, whether the residual is nan. If yes, raise a NotConvergedError."""


### PR DESCRIPTION
In this PR, the Newton solver is changed so that the user-specified values for the relative tolerance for the (inner) linear systems, set via the ksp_options, is respected - unless an inexact Newton's method is chosen with the kwarg `inexact=True`