### PR TITLE
Increase precision of Gmsh output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ of the maintenance releases, please take a look at
 2.2.0 (in development)
 ----------------------
 
+* Increase the precision of the Gmsh output from cashocs
+
 
 2.1.0 (February 6, 2024)
 ------------------------

--- a/cashocs/io/mesh.py
+++ b/cashocs/io/mesh.py
@@ -355,14 +355,14 @@ def create_point_representation(
     mod_line = ""
     if dim == 2:
         mod_line = (
-            f"{points[idcs[subwrite_counter]][0]:.16f} "
-            f"{points[idcs[subwrite_counter]][1]:.16f} 0\n"
+            f"{points[idcs[subwrite_counter]][0]:.16e} "
+            f"{points[idcs[subwrite_counter]][1]:.16e} 0\n"
         )
     elif dim == 3:
         mod_line = (
-            f"{points[idcs[subwrite_counter]][0]:.16f} "
-            f"{points[idcs[subwrite_counter]][1]:.16f} "
-            f"{points[idcs[subwrite_counter]][2]:.16f}\n"
+            f"{points[idcs[subwrite_counter]][0]:.16e} "
+            f"{points[idcs[subwrite_counter]][1]:.16e} "
+            f"{points[idcs[subwrite_counter]][2]:.16e}\n"
         )
 
     return mod_line


### PR DESCRIPTION
This changes the output format of the vertex positions from .16f to .16e, i.e., machine precision, when exporting the mesh from cashocs to Gmsh.