### PR TITLE
Add an interface for PETSc SNES

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,11 +10,17 @@ of the maintenance releases, please take a look at
 2.2.0 (in development)
 ----------------------
 
+* Add a wrapper for PETSc's SNES solver for nonlinear equations. This is used internally in cashocs whenever possible. For the solution of the state system, our own Newton solver is the default for backwards compatibility. Users can use the new SNES backend by specifying :ini:`backend = petsc` in the Section StateSystem of the configuration.
+
 * Increase the precision of the Gmsh output from cashocs
 
 * Add mesh quality constraints for shape optimization: These ensure that the angles of the triangles / dihedral angles of tetrahedrons cannot fall below a specified threshold.
 
 * New configuration file parameters:
+
+  * Section StateSystem
+  
+    * :ini:`backend` specifies which backend is used for solving nonlinear equations. The default is :ini:`backend = cashocs`, which is the "old" behavior, and :ini:`backend = petsc` uses the new PETSc SNES interface.
 
   * Section ShapeGradient
 

--- a/cashocs/__init__.py
+++ b/cashocs/__init__.py
@@ -58,6 +58,7 @@ from cashocs.io import load_config
 from cashocs.nonlinear_solvers import linear_solve
 from cashocs.nonlinear_solvers import newton_solve
 from cashocs.nonlinear_solvers import picard_iteration
+from cashocs.nonlinear_solvers import snes_solve
 
 __version__ = "2.2.0-dev"
 
@@ -155,4 +156,5 @@ __all__ = [
     "linear_solve",
     "TopologyOptimizationProblem",
     "interpolate_levelset_function_to_cells",
+    "snes_solve",
 ]

--- a/cashocs/_exceptions.py
+++ b/cashocs/_exceptions.py
@@ -61,8 +61,8 @@ class NotConvergedError(CashocsException):
         return main_msg + post_msg
 
 
-class PETScKSPError(CashocsException):
-    """This exception is raised when the solution of a linear problem with PETSc fails.
+class PETScError(CashocsException):
+    """This exception is raised when the solution of a problem with PETSc fails.
 
     Also returns the PETSc error code and reason.
     """
@@ -70,7 +70,7 @@ class PETScKSPError(CashocsException):
     def __init__(
         self,
         error_code: int,
-        message: str = "PETSc linear solver did not converge.",
+        message: str = "The PETSc solver did not converge.",
     ) -> None:
         """Initializes self.
 
@@ -82,7 +82,35 @@ class PETScKSPError(CashocsException):
         super().__init__()
         self.message = message
         self.error_code = error_code
+        self.error_dict: dict[int, str] = {}
 
+    def __str__(self) -> str:
+        """Returns the string representation of the exception."""
+        return (
+            f"{self.message} ConvergedReason = "
+            f"{self.error_code} {self.error_dict[self.error_code]}"
+        )
+
+
+class PETScKSPError(PETScError):
+    """This exception is raised when the solution of a linear problem with PETSc fails.
+
+    Also returns the PETSc error code and reason.
+    """
+
+    def __init__(
+        self,
+        error_code: int,
+        message: str = "The PETSc linear solver did not converge.",
+    ) -> None:
+        """Initializes self.
+
+        Args:
+            error_code: The error code issued by PETSc.
+            message: The message, detailing why PETSc issued an error.
+
+        """
+        super().__init__(error_code, message)
         self.error_dict = {
             -2: " (ksp_diverged_null)",
             -3: " (ksp_diverged_its, reached maximum iterations)",
@@ -102,12 +130,48 @@ class PETScKSPError(CashocsException):
             "it was not possible to build / use the preconditioner)",
         }
 
-    def __str__(self) -> str:
-        """Returns the string representation of the exception."""
-        return (
-            f"{self.message} KSPConvergedReason = "
-            f"{self.error_code} {self.error_dict[self.error_code]}"
-        )
+
+class PETScSNESError(PETScError):
+    """This exception is raised if the solution of a nonlinear problem with PETSc fails.
+
+    Also returns the PETSc error code and reason.
+    """
+
+    def __init__(
+        self,
+        error_code: int,
+        message: str = "The PETSc nonlinear solver did not converge.",
+    ) -> None:
+        """Initializes self.
+
+        Args:
+            error_code: The error code issued by PETSc.
+            message: The message, detailing why PETSc issued an error.
+
+        """
+        super().__init__(error_code, message)
+        self.error_dict = {
+            -1: (
+                " (snes_diverged_function_domain, "
+                "the new x location passed to the function is not in the domain)"
+            ),
+            -2: " (snes_diverged_function_count)",
+            -3: " (snes_diverged_linear_solve, linear solve failed)",
+            -4: " (snes_diverged_fnorm_nan)",
+            -5: " (snes_diverged_max_it, maximum number of iterations exceeded)",
+            -6: " (snes_diverged_line_search, the line search failed)",
+            -7: " (snes_diverged_inner, inner solve failed)",
+            -8: (
+                " (snes_diverged_local_min, ||J^T b|| is small, "
+                "implies converged to local minimum)"
+            ),
+            -9: " (snes_diverged_dtol, ||F|| > divtol*||F_initial||)",
+            -10: (
+                " (snes_diverged_jacobian_domain, "
+                "Jacobian calculation does not make sense)"
+            ),
+            -11: " (snes_diverged_tr_delta)",
+        }
 
 
 class InputError(CashocsException):

--- a/cashocs/_optimization/optimization_algorithms/optimization_algorithm.py
+++ b/cashocs/_optimization/optimization_algorithms/optimization_algorithm.py
@@ -258,7 +258,7 @@ class OptimizationAlgorithm(abc.ABC):
 
         else:
             self.objective_value = self.cost_functional.evaluate()
-            self.gradient_norm = np.NAN
+            self.gradient_norm = np.nan
             self.relative_norm = np.nan
             # maximum iterations reached
             if self.converged_reason == -1:

--- a/cashocs/_optimization/shape_optimization/mesh_constraint_manager.py
+++ b/cashocs/_optimization/shape_optimization/mesh_constraint_manager.py
@@ -411,7 +411,7 @@ class ConstraintManager:
                 if self.comm.rank == lambda_min_rank:
                     i_min_list = np.argsort(lambd_ineq)
                     i_min_list_padded = np.where(self.inequality_mask)[0][i_min_list]
-                    mask = ~np.in1d(i_min_list_padded, undroppable_idx)
+                    mask = ~np.isin(i_min_list_padded, undroppable_idx)
                     i_min_padded = i_min_list_padded[mask][0]
 
                     active_idx[i_min_padded] = False

--- a/cashocs/_optimization/topology_optimization/topology_optimization_problem.py
+++ b/cashocs/_optimization/topology_optimization/topology_optimization_problem.py
@@ -202,7 +202,7 @@ class TopologyOptimizationProblem(_optimization.OptimizationProblem):
         self.topological_derivative_is_identical = self.config.getboolean(
             "TopologyOptimization", "topological_derivative_is_identical"
         )
-        self.re_normalize_levelset = self.config.getboolean(
+        self.re_normalize_levelset: bool = self.config.getboolean(
             "TopologyOptimization", "re_normalize_levelset"
         )
         self.normalize_topological_derivative = self.config.getboolean(

--- a/cashocs/_pde_problems/adjoint_problem.py
+++ b/cashocs/_pde_problems/adjoint_problem.py
@@ -141,16 +141,11 @@ class AdjointProblem(pde_problem.PDEProblem):
                     rtol=self.picard_rtol,
                     atol=self.picard_atol,
                     verbose=self.picard_verbose,
-                    inner_damped=False,
-                    inner_inexact=False,
-                    inner_verbose=False,
                     inner_max_iter=2,
                     ksp_options=self.db.parameter_db.adjoint_ksp_options[::-1],
                     A_tensors=self.A_tensors[::-1],
                     b_tensors=self.b_tensors[::-1],
-                    inner_is_linear=True,
                     preconditioner_forms=self.db.form_db.preconditioner_forms[::-1],
-                    linear_solver=self.linear_solver,
                 )
 
             self.has_solution = True

--- a/cashocs/_pde_problems/hessian_problems.py
+++ b/cashocs/_pde_problems/hessian_problems.py
@@ -201,14 +201,10 @@ class HessianProblem:
                 rtol=self.picard_rtol,
                 atol=self.picard_atol,
                 verbose=self.picard_verbose,
-                inner_damped=False,
-                inner_inexact=False,
-                inner_verbose=False,
                 inner_max_iter=2,
                 ksp_options=self.db.parameter_db.state_ksp_options,
                 A_tensors=self.state_A_tensors,
                 b_tensors=self.state_b_tensors,
-                inner_is_linear=True,
                 preconditioner_forms=self.db.form_db.preconditioner_forms,
             )
 
@@ -220,14 +216,10 @@ class HessianProblem:
                 rtol=self.picard_rtol,
                 atol=self.picard_atol,
                 verbose=self.picard_verbose,
-                inner_damped=False,
-                inner_inexact=False,
-                inner_verbose=False,
                 inner_max_iter=2,
                 ksp_options=self.db.parameter_db.adjoint_ksp_options,
                 A_tensors=self.adjoint_A_tensors,
                 b_tensors=self.adjoint_b_tensors,
-                inner_is_linear=True,
                 preconditioner_forms=self.db.form_db.preconditioner_forms,
             )
 

--- a/cashocs/_pde_problems/shape_gradient_problem.py
+++ b/cashocs/_pde_problems/shape_gradient_problem.py
@@ -238,7 +238,7 @@ class _PLaplaceProjector:
         for nonlinear_form in self.form_list:
             petsc_options: _typing.KspOption = {
                 "snes_type": "newtonls",
-                # "snes_monitor_short": None,
+                "snes_linesearch_type": "basic",
                 "snes_ksp_ew": True,
             }
             petsc_options.update(self.ksp_options)

--- a/cashocs/_pde_problems/shape_gradient_problem.py
+++ b/cashocs/_pde_problems/shape_gradient_problem.py
@@ -36,13 +36,13 @@ except ImportError:
     import ufl
 
 from cashocs import _loggers
-from cashocs import _typing
 from cashocs import _utils
 from cashocs import nonlinear_solvers
 from cashocs._pde_problems import pde_problem
 
 if TYPE_CHECKING:
     from cashocs import _forms
+    from cashocs import _typing
     from cashocs._database import database
     from cashocs._pde_problems import adjoint_problem as ap
     from cashocs._pde_problems import state_problem as sp

--- a/cashocs/_pde_problems/shape_gradient_problem.py
+++ b/cashocs/_pde_problems/shape_gradient_problem.py
@@ -36,6 +36,7 @@ except ImportError:
     import ufl
 
 from cashocs import _loggers
+from cashocs import _typing
 from cashocs import _utils
 from cashocs import nonlinear_solvers
 from cashocs._pde_problems import pde_problem
@@ -235,15 +236,19 @@ class _PLaplaceProjector:
         self.solution.vector().vec().set(0.0)
         self.solution.vector().apply("")
         for nonlinear_form in self.form_list:
-            nonlinear_solvers.newton_solve(
+            petsc_options: _typing.KspOption = {
+                "snes_type": "newtonls",
+                # "snes_monitor_short": None,
+                "snes_ksp_ew": True,
+            }
+            petsc_options.update(self.ksp_options)
+
+            nonlinear_solvers.snes_solve(
                 nonlinear_form,
                 self.solution,
                 self.bcs_shape,
+                petsc_options=petsc_options,
                 shift=self.shape_derivative,
-                damped=False,
-                inexact=True,
-                verbose=False,
-                ksp_options=self.ksp_options,
                 A_tensor=self.A_tensor,
                 b_tensor=self.b_tensor,
             )

--- a/cashocs/_pde_problems/state_problem.py
+++ b/cashocs/_pde_problems/state_problem.py
@@ -154,22 +154,16 @@ class StateProblem(pde_problem.PDEProblem):
                     for i in range(self.db.parameter_db.state_dim):
                         if self.initial_guess is not None:
                             fenics.assign(self.states[i], self.initial_guess[i])
-                        nonlinear_solvers.newton_solve(
+
+                        nonlinear_solvers.snes_solve(
                             self.state_form_handler.state_eq_forms[i],
                             self.states[i],
                             self.bcs_list[i],
                             derivative=self.newton_linearizations[i],
-                            rtol=self.newton_rtol,
-                            atol=self.newton_atol,
-                            max_iter=self.newton_iter,
-                            damped=self.newton_damped,
-                            inexact=self.newton_inexact,
-                            verbose=self.newton_verbose,
-                            ksp_options=self.db.parameter_db.state_ksp_options[i],
+                            petsc_options=self.db.parameter_db.state_ksp_options[i],
                             A_tensor=self.A_tensors[i],
                             b_tensor=self.b_tensors[i],
                             preconditioner_form=self.db.form_db.preconditioner_forms[i],
-                            linear_solver=self.linear_solver,
                         )
 
             else:
@@ -181,16 +175,11 @@ class StateProblem(pde_problem.PDEProblem):
                     rtol=self.picard_rtol,
                     atol=self.picard_atol,
                     verbose=self.picard_verbose,
-                    inner_damped=self.newton_damped,
-                    inner_inexact=self.newton_inexact,
-                    inner_verbose=self.newton_verbose,
                     inner_max_iter=self.newton_iter,
                     ksp_options=self.db.parameter_db.state_ksp_options,
                     A_tensors=self.A_tensors,
                     b_tensors=self.b_tensors,
-                    inner_is_linear=self.config.getboolean("StateSystem", "is_linear"),
                     preconditioner_forms=self.db.form_db.preconditioner_forms,
-                    linear_solver=self.linear_solver,
                     newton_linearizations=self.newton_linearizations,
                 )
 

--- a/cashocs/_utils/linalg.py
+++ b/cashocs/_utils/linalg.py
@@ -333,8 +333,8 @@ def solve_linear_problem(
     """Solves a finite dimensional linear problem.
 
     An overview over possible command line options for the PETSc KSP object can
-    be found at `https://petsc.org/release/manualpages/KSP/`_ and options for the
-    preconditioners can be found at `https://petsc.org/release/manualpages/PC/`_.
+    be found at `<https://petsc.org/release/manualpages/KSP/>`_ and options for the
+    preconditioners can be found at `<https://petsc.org/release/manualpages/PC/>`_.
 
     Args:
         A: The PETSc matrix corresponding to the left-hand side of the problem. If

--- a/cashocs/_utils/linalg.py
+++ b/cashocs/_utils/linalg.py
@@ -180,7 +180,7 @@ def assemble_petsc_system(
 
 
 def setup_petsc_options(
-    ksps: List[PETSc.KSP], ksp_options: List[_typing.KspOption]
+    objs: List[PETSc.KSP | PETSc.SNES], ksp_options: List[_typing.KspOption]
 ) -> None:
     """Sets up an (iterative) linear solver.
 
@@ -188,22 +188,22 @@ def setup_petsc_options(
     to the PETSc KSP objects. Here, options[i] is applied to ksps[i].
 
     Args:
-        ksps: A list of PETSc KSP objects (linear solvers) to which the (command line)
+        objs: A list of PETSc objects (e.g. linear solvers) to which the (command line)
             options are applied to.
-        ksp_options: A list of command line options that specify the iterative solver
+        ksp_options: A list of command line options that specify the solver
             from PETSc.
 
     """
     fenics.PETScOptions.clear()
     opts = PETSc.Options()
 
-    for i in range(len(ksps)):
+    for i in range(len(objs)):
         opts.clear()
 
         for key, value in ksp_options[i].items():
             opts.setValue(key, value)
 
-        ksps[i].setFromOptions()
+        objs[i].setFromOptions()
 
 
 def setup_fieldsplit_preconditioner(

--- a/cashocs/_utils/linalg.py
+++ b/cashocs/_utils/linalg.py
@@ -332,6 +332,10 @@ def solve_linear_problem(
 ) -> PETSc.Vec:
     """Solves a finite dimensional linear problem.
 
+    An overview over possible command line options for the PETSc KSP object can
+    be found at `https://petsc.org/release/manualpages/KSP/`_ and options for the
+    preconditioners can be found at `https://petsc.org/release/manualpages/PC/`_.
+
     Args:
         A: The PETSc matrix corresponding to the left-hand side of the problem. If
             this is None, then the matrix stored in the ksp object is used. Raises

--- a/cashocs/io/config.py
+++ b/cashocs/io/config.py
@@ -150,6 +150,10 @@ class Config(ConfigParser):
                 "picard_verbose": {
                     "type": "bool",
                 },
+                "backend": {
+                    "type": "str",
+                    "possible_options": ["cashocs", "petsc"],
+                },
             },
             "OptimizationRoutine": {
                 "algorithm": {
@@ -576,6 +580,7 @@ picard_rtol = 1e-10
 picard_atol = 1e-12
 picard_iter = 50
 picard_verbose = False
+backend = cashocs
 
 [OptimizationRoutine]
 algorithm = none

--- a/cashocs/nonlinear_solvers/__init__.py
+++ b/cashocs/nonlinear_solvers/__init__.py
@@ -24,5 +24,6 @@ a Picard iteration for coupled problems.
 from cashocs.nonlinear_solvers.linear_solver import linear_solve
 from cashocs.nonlinear_solvers.newton_solver import newton_solve
 from cashocs.nonlinear_solvers.picard_solver import picard_iteration
+from cashocs.nonlinear_solvers.snes import snes_solve
 
-__all__ = ["newton_solve", "picard_iteration", "linear_solve"]
+__all__ = ["newton_solve", "picard_iteration", "linear_solve", "snes_solve"]

--- a/cashocs/nonlinear_solvers/picard_solver.py
+++ b/cashocs/nonlinear_solvers/picard_solver.py
@@ -31,7 +31,7 @@ except ImportError:
 
 from cashocs import _exceptions
 from cashocs import _utils
-from cashocs.nonlinear_solvers import newton_solver
+from cashocs.nonlinear_solvers import snes
 
 if TYPE_CHECKING:
     from cashocs import _typing
@@ -97,17 +97,12 @@ def picard_iteration(
     rtol: float = 1e-10,
     atol: float = 1e-10,
     verbose: bool = True,
-    inner_damped: bool = True,
-    inner_inexact: bool = True,
-    inner_verbose: bool = False,
     inner_max_iter: int = 25,
     ksp_options: Optional[List[_typing.KspOption]] = None,
     # pylint: disable=invalid-name
     A_tensors: Optional[List[fenics.PETScMatrix]] = None,
     b_tensors: Optional[List[fenics.PETScVector]] = None,
-    inner_is_linear: bool = False,
     preconditioner_forms: Optional[Union[List[ufl.Form], ufl.Form]] = None,
-    linear_solver: Optional[_utils.linalg.LinearSolver] = None,
     newton_linearizations: Optional[List[ufl.Form]] = None,
 ) -> None:
     """Solves a system of coupled PDEs via a Picard iteration.
@@ -121,12 +116,6 @@ def picard_iteration(
         atol: The absolute tolerance for the Picard iteration, default is 1e-10.
         verbose: Boolean flag, if ``True``, output is written to stdout, default is
             ``True``.
-        inner_damped: Boolean flag, if ``True``, the inner problems are solved with a
-            damped Newton method, default is ``True``
-        inner_inexact: Boolean flag, if ``True``, the inner problems are solved with an
-            inexact Newton method, default is ``True``
-        inner_verbose: Boolean flag, if ``True``, the inner problems write the history
-            to stdout, default is ``False``.
         inner_max_iter: Maximum number of iterations for the inner Newton solver;
             default is 25.
         ksp_options: List of options for the KSP objects.
@@ -134,13 +123,9 @@ def picard_iteration(
             equations.
         b_tensors: List of vectors for the left-hand sides of the inner (linearized)
             equations.
-        inner_is_linear: Boolean flag, if this is ``True``, all problems are actually
-            linear ones, and only a linear solver is used.
         preconditioner_forms: The list of forms for the preconditioner. The default
             is `None`, so that the preconditioner matrix is the same as the system
             matrix.
-        linear_solver: The linear solver (KSP) which is used to solve the linear
-            systems arising from the discretized PDE.
         newton_linearizations: A list of UFL forms describing which (alternative)
             linearizations should be used for the (nonlinear) equations when
             solving them (with Newton's method). The default is `None`, so that the
@@ -196,23 +181,18 @@ def picard_iteration(
                 j, ksp_options, A_tensors, b_tensors
             )
 
-            newton_solver.newton_solve(
+            snes.snes_solve(
                 form_list[j],
                 u_list[j],
                 bcs_list[j],
                 derivative=newton_linearization_list[j],
+                petsc_options=ksp_option,
                 rtol=eta,
                 atol=atol * 1e-1,
                 max_iter=inner_max_iter,
-                damped=inner_damped,
-                inexact=inner_inexact,
-                verbose=inner_verbose,
-                ksp_options=ksp_option,
                 A_tensor=A_tensor,
                 b_tensor=b_tensor,
-                is_linear=inner_is_linear,
                 preconditioner_form=preconditioner_form_list[j],
-                linear_solver=linear_solver,
             )
 
     if is_printing:

--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -242,6 +242,9 @@ def snes_solve(
 ) -> fenics.Function:
     """Solve a nonlinear PDE problem with PETSc SNES.
 
+    An overview over possible PETSc command line options for the SNES can be found
+    at `https://petsc.org/release/manualpages/SNES/`_.
+
     Args:
         nonlinear_form: The variational form of the nonlinear problem to be solved
             by Newton's method.

--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -1,0 +1,233 @@
+# Copyright (C) 2020-2024 Sebastian Blauth
+#
+# This file is part of cashocs.
+#
+# cashocs is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cashocs is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cashocs.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Interface for the PETSc SNES solver for nonlinear equations."""
+
+from __future__ import annotations
+
+import copy
+from typing import List, Optional, TYPE_CHECKING, Union
+
+import fenics
+from petsc4py import PETSc
+
+try:
+    import ufl_legacy as ufl
+except ImportError:
+    import ufl
+
+from cashocs import _utils
+
+if TYPE_CHECKING:
+    from cashocs import _typing
+
+
+default_snes_options = {
+    "snes_type": "newtonls",
+    "snes_monitor_short": None,
+}
+
+
+class SNESSolver:
+    """Interface for using PETSc's SNES solver."""
+
+    def __init__(
+        self,
+        nonlinear_form: ufl.Form,
+        u: fenics.Function,
+        bcs: Union[fenics.DirichletBC, List[fenics.DirichletBC]],
+        derivative: Optional[ufl.Form] = None,
+        petsc_options: Optional[_typing.KspOption] = None,
+        A_tensor: Optional[fenics.PETScMatrix] = None,  # pylint: disable=invalid-name
+        b_tensor: Optional[fenics.PETScVector] = None,
+        preconditioner_form: Optional[ufl.Form] = None,
+    ) -> None:
+        """Initialize the SNES solver.
+
+        Args:
+            nonlinear_form: The variational form of the nonlinear problem to be solved
+                by Newton's method.
+            u: The sought solution / initial guess. It is not assumed that the initial
+                guess satisfies the Dirichlet boundary conditions, they are applied
+                automatically. The method overwrites / updates this Function.
+            bcs: A list of DirichletBCs for the nonlinear variational problem.
+            derivative: The Jacobian of nonlinear_form, used for the Newton method.
+                Default is None, and in this case the Jacobian is computed automatically
+                with AD.
+            petsc_options: The options for PETSc.
+            A_tensor: A fenics.PETScMatrix for storing the left-hand side of the linear
+                sub-problem.
+            b_tensor: A fenics.PETScVector for storing the right-hand side of the linear
+                sub-problem.
+            preconditioner_form: A UFL form which defines the preconditioner matrix.
+
+        """
+        self.nonlinear_form = nonlinear_form
+        self.u = u
+        self.comm = self.u.function_space().mesh().mpi_comm()
+        self.bcs = _utils.enlist(bcs)
+
+        if petsc_options is None:
+            self.petsc_options = copy.deepcopy(default_snes_options)
+            self.petsc_options.update(_utils.linalg.direct_ksp_options)  # type: ignore
+        else:
+            self.petsc_options = petsc_options  # type: ignore
+
+        self.A_tensor = A_tensor  # pylint: disable=invalid-name
+        self.b_tensor = b_tensor
+
+        if preconditioner_form is not None:
+            if len(preconditioner_form.arguments()) == 1:
+                self.preconditioner_form = fenics.derivative(
+                    preconditioner_form, self.u
+                )
+            else:
+                self.preconditioner_form = preconditioner_form
+        else:
+            self.preconditioner_form = None
+
+        temp_derivative = derivative or fenics.derivative(self.nonlinear_form, self.u)
+        self.derivative = _utils.bilinear_boundary_form_modification([temp_derivative])[
+            0
+        ]
+
+        self.assembler = fenics.SystemAssembler(
+            self.derivative, self.nonlinear_form, self.bcs
+        )
+        self.assembler.keep_diagonal = True
+
+        if self.preconditioner_form is not None:
+            self.assembler_pc = fenics.SystemAssembler(
+                self.preconditioner_form, self.nonlinear_form, self.bcs
+            )
+            self.assembler_pc.keep_diagonal = True
+
+        self.A_fenics = (  # pylint: disable=invalid-name
+            self.A_tensor or fenics.PETScMatrix(self.comm)
+        )
+        self.residual = self.b_tensor or fenics.PETScVector(self.comm)
+        self.b = fenics.as_backend_type(self.residual).vec()
+
+        self.P_fenics = fenics.PETScMatrix(self.comm)  # pylint: disable=invalid-name
+
+    def assemble_function(
+        self,
+        snes: PETSc.SNES,  # pylint: disable=unused-argument
+        x: PETSc.Vec,
+        f: PETSc.Vec,
+    ) -> None:
+        """Interface for PETSc SNESSetFunction.
+
+        Args:
+            snes: The SNES solver
+            x: The current iterate
+            f: The vector in which the function evaluation is stored.
+
+        """
+        self.u.vector().vec().setArray(x)
+        f = fenics.PETScVector(f)
+
+        self.assembler.assemble(f, self.u.vector())
+
+    def assemble_jacobian(
+        self,
+        snes: PETSc.SNES,  # pylint: disable=unused-argument
+        x: PETSc.Vec,
+        J: PETSc.Mat,  # pylint: disable=invalid-name,
+        P: PETSc.Mat,  # pylint: disable=invalid-name
+    ) -> None:
+        """Interface for PETSc SNESSetJacobian.
+
+        Args:
+            snes: The SNES solver.
+            x: The current iterate.
+            J: The matrix storing the Jacobian.
+            P: The matrix storing the preconditioner for the Jacobian.
+
+        """
+        self.u.vector().vec().setArray(x)
+        J = fenics.PETScMatrix(J)  # pylint: disable=invalid-name
+        P = fenics.PETScMatrix(P)  # pylint: disable=invalid-name
+
+        self.assembler.assemble(J)
+        J.ident_zeros()
+
+        if self.preconditioner_form is not None:
+            self.assembler_pc.assemble(P)
+            P.ident_zeros()
+
+    def solve(self) -> fenics.Function:
+        """Solves the nonlinear problem with PETSc's SNES."""
+        snes = PETSc.SNES().create()
+
+        snes.setFunction(self.assemble_function, self.residual.vec())
+        snes.setJacobian(
+            self.assemble_jacobian, self.A_fenics.mat(), self.P_fenics.mat()
+        )
+
+        _utils.setup_petsc_options([snes], [self.petsc_options])  # type: ignore
+        snes.solve(None, self.u.vector().vec())
+
+        return self.u
+
+
+def snes_solve(
+    nonlinear_form: ufl.Form,
+    u: fenics.Function,
+    bcs: Union[fenics.DirichletBC, List[fenics.DirichletBC]],
+    derivative: Optional[ufl.Form] = None,
+    petsc_options: Optional[_typing.KspOption] = None,
+    A_tensor: Optional[fenics.PETScMatrix] = None,  # pylint: disable=invalid-name
+    b_tensor: Optional[fenics.PETScVector] = None,
+    preconditioner_form: Optional[ufl.Form] = None,
+) -> fenics.Function:
+    """Solve a nonlinear PDE problem with PETSc SNES.
+
+    Args:
+        nonlinear_form: The variational form of the nonlinear problem to be solved
+            by Newton's method.
+        u: The sought solution / initial guess. It is not assumed that the initial
+            guess satisfies the Dirichlet boundary conditions, they are applied
+            automatically. The method overwrites / updates this Function.
+        bcs: A list of DirichletBCs for the nonlinear variational problem.
+        derivative: The Jacobian of nonlinear_form, used for the Newton method.
+            Default is None, and in this case the Jacobian is computed automatically
+            with AD.
+        petsc_options: The options for PETSc.
+        A_tensor: A fenics.PETScMatrix for storing the left-hand side of the linear
+            sub-problem.
+        b_tensor: A fenics.PETScVector for storing the right-hand side of the linear
+            sub-problem.
+        preconditioner_form: A UFL form which defines the preconditioner matrix.
+
+    Returns:
+        The solution in form of a FEniCS Function.
+
+    """
+    solver = SNESSolver(
+        nonlinear_form,
+        u,
+        bcs,
+        derivative,
+        petsc_options,
+        A_tensor,
+        b_tensor,
+        preconditioner_form,
+    )
+
+    solution = solver.solve()
+    return solution

--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -245,7 +245,7 @@ def snes_solve(
     """Solve a nonlinear PDE problem with PETSc SNES.
 
     An overview over possible PETSc command line options for the SNES can be found
-    at `https://petsc.org/release/manualpages/SNES/`_.
+    at `<https://petsc.org/release/manualpages/SNES/>`_.
 
     Args:
         nonlinear_form: The variational form of the nonlinear problem to be solved

--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -73,7 +73,7 @@ class SNESSolver:
             derivative: The Jacobian of nonlinear_form, used for the Newton method.
                 Default is None, and in this case the Jacobian is computed automatically
                 with AD.
-            petsc_options: The options for PETSc.
+            petsc_options: The options for PETSc SNES object.
             shift: A shift term, if the right-hand side of the nonlinear problem is not
                 zero, but shift.
             rtol: Relative tolerance of the solver (default is ``rtol = 1e-10``).
@@ -257,7 +257,7 @@ def snes_solve(
         derivative: The Jacobian of nonlinear_form, used for the Newton method.
             Default is None, and in this case the Jacobian is computed automatically
             with AD.
-        petsc_options: The options for PETSc.
+        petsc_options: The options for PETSc SNES object.
         shift: A shift term, if the right-hand side of the nonlinear problem is not
             zero, but shift.
         rtol: Relative tolerance of the solver (default is ``rtol = 1e-10``).

--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -167,6 +167,7 @@ class SNESSolver:
 
         """
         self.u.vector().vec().setArray(x)
+        self.u.vector().apply("")
         f = fenics.PETScVector(f)
 
         self.assembler.assemble(f, self.u.vector())
@@ -195,6 +196,7 @@ class SNESSolver:
 
         """
         self.u.vector().vec().setArray(x)
+        self.u.vector().apply("")
 
         J = fenics.PETScMatrix(J)  # pylint: disable=invalid-name
         self.assembler.assemble(J)

--- a/demos/documented/optimal_control/pre_post_callbacks/demo_pre_post_callbacks.py
+++ b/demos/documented/optimal_control/pre_post_callbacks/demo_pre_post_callbacks.py
@@ -138,7 +138,7 @@ def pre_callback():
         - q * div(u) * dx
         - inner(c, v) * dx
     )
-    cashocs.newton_solve(e, up, bcs, verbose=False)
+    cashocs.snes_solve(e, up, bcs)
 
 
 # where we solve the Navier-Stokes equations with a lower Reynolds number of

--- a/demos/documented/shape_optimization/space_mapping_semilinear_transmission/demo_space_mapping_semilinear_transmission.py
+++ b/demos/documented/shape_optimization/space_mapping_semilinear_transmission/demo_space_mapping_semilinear_transmission.py
@@ -170,7 +170,7 @@ def create_desired_state(alpha_1, alpha_2, beta, f_1, f_2):
         - Constant(f_2) * v * dx(2)
     )
     bcs = cashocs.create_dirichlet_bcs(V, Constant(0.0), boundaries, [1, 2, 3, 4])
-    cashocs.newton_solve(F, u, bcs, verbose=False)
+    cashocs.snes_solve(F, u, bcs)
 
     return u
 
@@ -255,7 +255,7 @@ class FineModel(space_mapping.FineModel):
             - Constant(self.f_2) * v * dx(2)
         )
         bcs = cashocs.create_dirichlet_bcs(V, Constant(0.0), boundaries, [1, 2, 3, 4])
-        cashocs.newton_solve(F, u, bcs, verbose=False)
+        cashocs.snes_solve(F, u, bcs)
 
         LagrangeInterpolator.interpolate(u_des, self.u_des_fixed)
 
@@ -312,7 +312,7 @@ class FineModel(space_mapping.FineModel):
 #     - Constant(self.f_2) * v * dx(2)
 # )
 # bcs = cashocs.create_dirichlet_bcs(V, Constant(0.0), boundaries, [1, 2, 3, 4])
-# cashocs.newton_solve(F, u, bcs, verbose=False)
+# cashocs.snes_solve(F, u, bcs)
 # :::
 #
 # After solving the fine model PDE constraint, we re-interpolate the desired state to

--- a/demos/documented/shape_optimization/space_mapping_uniform_flow_distribution/demo_space_mapping_uniform_flow_distribution.py
+++ b/demos/documented/shape_optimization/space_mapping_uniform_flow_distribution/demo_space_mapping_uniform_flow_distribution.py
@@ -285,7 +285,7 @@ class FineModel(space_mapping.FineModel):
         bc_pressure = DirichletBC(V.sub(1), Constant(0.0), boundaries, 5)
         bcs = [bc_in] + bcs_wall + [bc_out] + [bc_pressure]
 
-        cashocs.newton_solve(F, up, bcs, verbose=False)
+        cashocs.snes_solve(F, up, bcs)
         self.u, p = up.split(True)
 
         file = File(f"./pvd/u_{self.iter}.pvd")
@@ -416,9 +416,9 @@ fine_model = FineModel(mesh, Re, q_in, output_list)
 # bcs = [bc_in
 # :::
 #
-# The problem is then solved with {py:func}`<cashocs.newton_solve>`
+# The problem is then solved with {py:func}`<cashocs.snes_solve>`
 # :::{code-block} python
-# cashocs.newton_solve(F, up, bcs, verbose=False)
+# cashocs.snes_solve(F, up, bcs)
 # :::
 #
 # Finally, after having solved the problem, we first save the solution for later

--- a/docs/source/user/demos/optimal_control/doc_config.rst
+++ b/docs/source/user/demos/optimal_control/doc_config.rst
@@ -661,7 +661,7 @@ in the following.
     * - :ini:`picard_verbose = False`
       - :ini:`picard_verbose = True` enables verbose output of Picard iteration
     * - :ini:`backend = cashocs`
-        specifies the backend for solving nonlinear equations, can be either :ini:`cashocs` or :ini:`petsc`
+      - specifies the backend for solving nonlinear equations, can be either :ini:`cashocs` or :ini:`petsc`
 
 [OptimizationRoutine]
 *********************

--- a/docs/source/user/demos/optimal_control/doc_config.rst
+++ b/docs/source/user/demos/optimal_control/doc_config.rst
@@ -162,6 +162,20 @@ Picard iteration, and is set as follows
 
 Its default value is :ini:`False`.
 
+The parameter :ini:`backend` specifies which solver backend should be used for solving nonlinear systems.
+Its default value is given by
+
+.. code-block:: ini
+
+    backend = cashocs
+
+Possible options are :ini:`backend = cashocs` and :ini:`backend = petsc`. In the former case, a 
+damped, inexact Newton method which is affine co-variant is used. Its parameters are specified in the
+configuration above. In the latter case, PETSc's SNES interface for solving nonlinear equations
+is used which can be configured with the :py:`ksp_options` supplied by the user to the 
+:py:class:`cashocs.OptimizationProblem`. An overview over possible PETSc command line options
+can be found at `<https://petsc.org/release/manualpages/SNES/>`_.
+
 
 
 
@@ -646,6 +660,8 @@ in the following.
       - maximum iterations for Picard iteration
     * - :ini:`picard_verbose = False`
       - :ini:`picard_verbose = True` enables verbose output of Picard iteration
+    * - :ini:`backend = cashocs`
+        specifies the backend for solving nonlinear equations, can be either :ini:`cashocs` or :ini:`petsc`
 
 [OptimizationRoutine]
 *********************

--- a/docs/source/user/demos/optimal_control/doc_config.rst
+++ b/docs/source/user/demos/optimal_control/doc_config.rst
@@ -172,7 +172,7 @@ Its default value is given by
 Possible options are :ini:`backend = cashocs` and :ini:`backend = petsc`. In the former case, a 
 damped, inexact Newton method which is affine co-variant is used. Its parameters are specified in the
 configuration above. In the latter case, PETSc's SNES interface for solving nonlinear equations
-is used which can be configured with the :py:`ksp_options` supplied by the user to the 
+is used which can be configured with the `ksp_options` supplied by the user to the 
 :py:class:`cashocs.OptimizationProblem`. An overview over possible PETSc command line options
 can be found at `<https://petsc.org/release/manualpages/SNES/>`_.
 

--- a/docs/source/user/demos/shape_optimization/doc_config.rst
+++ b/docs/source/user/demos/shape_optimization/doc_config.rst
@@ -218,6 +218,20 @@ boolean flag
 
 which is set to :ini:`picard_verbose = False` by default.
 
+The parameter :ini:`backend` specifies which solver backend should be used for solving nonlinear systems.
+Its default value is given by
+
+.. code-block:: ini
+
+    backend = cashocs
+
+Possible options are :ini:`backend = cashocs` and :ini:`backend = petsc`. In the former case, a 
+damped, inexact Newton method which is affine co-variant is used. Its parameters are specified in the
+configuration above. In the latter case, PETSc's SNES interface for solving nonlinear equations
+is used which can be configured with the :py:`ksp_options` supplied by the user to the 
+:py:class:`cashocs.OptimizationProblem`. An overview over possible PETSc command line options
+can be found at `<https://petsc.org/release/manualpages/SNES/>`_.
+
 
 .. _config_shape_optimization_routine:
 
@@ -1218,6 +1232,9 @@ in the following.
       - maximum iterations for Picard iteration
     * - :ini:`picard_verbose = False`
       - :ini:`picard_verbose = True` enables verbose output of Picard iteration
+    * - :ini:`backend = cashocs`
+        specifies the backend for solving nonlinear equations, can be either :ini:`cashocs` or :ini:`petsc`
+
 
 
 [OptimizationRoutine]

--- a/docs/source/user/demos/shape_optimization/doc_config.rst
+++ b/docs/source/user/demos/shape_optimization/doc_config.rst
@@ -228,7 +228,7 @@ Its default value is given by
 Possible options are :ini:`backend = cashocs` and :ini:`backend = petsc`. In the former case, a 
 damped, inexact Newton method which is affine co-variant is used. Its parameters are specified in the
 configuration above. In the latter case, PETSc's SNES interface for solving nonlinear equations
-is used which can be configured with the :py:`ksp_options` supplied by the user to the 
+is used which can be configured with the `ksp_options` supplied by the user to the 
 :py:class:`cashocs.OptimizationProblem`. An overview over possible PETSc command line options
 can be found at `<https://petsc.org/release/manualpages/SNES/>`_.
 

--- a/docs/source/user/demos/shape_optimization/doc_config.rst
+++ b/docs/source/user/demos/shape_optimization/doc_config.rst
@@ -1233,7 +1233,7 @@ in the following.
     * - :ini:`picard_verbose = False`
       - :ini:`picard_verbose = True` enables verbose output of Picard iteration
     * - :ini:`backend = cashocs`
-        specifies the backend for solving nonlinear equations, can be either :ini:`cashocs` or :ini:`petsc`
+      - specifies the backend for solving nonlinear equations, can be either :ini:`cashocs` or :ini:`petsc`
 
 
 

--- a/tests/test_shape_optimization_space_mapping.py
+++ b/tests/test_shape_optimization_space_mapping.py
@@ -97,7 +97,7 @@ class FineModel(sosm.FineModel):
         bc_pressure = DirichletBC(V.sub(1), Constant(0.0), boundaries, 5)
         bcs = [bc_in] + bcs_wall + [bc_out] + [bc_pressure]
 
-        cashocs.newton_solve(F, up, bcs, verbose=False)
+        cashocs.snes_solve(F, up, bcs)
 
         J = cashocs.IntegralFunctional(
             Constant(0.5) * dot(u - u_des, u - u_des) * ds(5)


### PR DESCRIPTION
This PR adds a cashocs interface for using PETSc's SNES to solve nonlinear equations. 
In the optimization problem, users can choose between the old setting (custom newton solver) and the new one with the parameter `backend` (which can be `cashocs` or `petsc`). The default is the old system for compatibility reasons.

Closes #441 
Closes #423 
