### PR TITLE
Add destroy method and garbage cleanup for snes interface

### DIFF
--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -226,7 +226,7 @@ class SNESSolver:
             raise _exceptions.PETScSNESError(converged_reason)
 
         if hasattr(PETSc, "garbage_cleanup"):
-            snes.destory()
+            snes.destroy()
             PETSc.garbage_cleanup(comm=self.comm)
             PETSc.garbage_cleanup()
 

--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -225,6 +225,11 @@ class SNESSolver:
         if converged_reason < 0:
             raise _exceptions.PETScSNESError(converged_reason)
 
+        if hasattr(PETSc, "garbage_cleanup"):
+            snes.destory()
+            PETSc.garbage_cleanup(comm=self.comm)
+            PETSc.garbage_cleanup()
+
         return self.u
 
 


### PR DESCRIPTION
This is done to prevent possible memory leaks.