### PR TITLE
Avoid PETSc segfaults due to DMCollection

### DIFF
--- a/cashocs/_forms/control_form_handler.py
+++ b/cashocs/_forms/control_form_handler.py
@@ -173,7 +173,7 @@ class ControlFormHandler(form_handler.FormHandler):
             x = fenics.as_backend_type(a[i].vector()).vec()
             y = fenics.as_backend_type(b[i].vector()).vec()
 
-            temp, _ = self.riesz_projection_matrices[i].getVecs()
+            temp = self.riesz_projection_matrices[i].createVecRight()
             self.riesz_projection_matrices[i].mult(x, temp)
             result += temp.dot(y)
 

--- a/cashocs/_forms/shape_form_handler.py
+++ b/cashocs/_forms/shape_form_handler.py
@@ -680,7 +680,7 @@ class ShapeFormHandler(form_handler.FormHandler):
             x = fenics.as_backend_type(a[0].vector()).vec()
             y = fenics.as_backend_type(b[0].vector()).vec()
 
-            temp, _ = self.scalar_product_matrix.getVecs()
+            temp = self.scalar_product_matrix.createVecRight()
             self.scalar_product_matrix.mult(x, temp)
             result = temp.dot(y)
 

--- a/cashocs/_optimization/line_search/line_search.py
+++ b/cashocs/_optimization/line_search/line_search.py
@@ -122,9 +122,9 @@ class LineSearch(abc.ABC):
 
             transfer_matrix = cast(PETSc.Mat, transfer_matrix)
 
-            _, temp = transfer_matrix.getVecs()
-            transfer_matrix.mult(x, temp)
-            self.global_deformation_vector.axpy(1.0, temp)
+            transfer_matrix.multAdd(
+                x, self.global_deformation_vector, self.global_deformation_vector
+            )
             self.deformation_function.vector().apply("")
 
         self.post_line_search()

--- a/cashocs/_utils/linalg.py
+++ b/cashocs/_utils/linalg.py
@@ -482,10 +482,10 @@ class LinearSolver:
         A = setup_matrix_and_preconditioner(ksp, A, P)
 
         if b is None:
-            return A.getVecs()[0]
+            return A.createVecRight()
 
         if fun is None:
-            x, _ = A.getVecs()
+            x = A.createVecRight()
         else:
             x = fun.vector().vec()
 

--- a/cashocs/_utils/linalg.py
+++ b/cashocs/_utils/linalg.py
@@ -602,9 +602,7 @@ class Interpolator:
         """
         v = fenics.Function(self.target_space)
         x = fenics.as_backend_type(u.vector()).vec()
-        _, temp = self.transfer_matrix.getVecs()
-        self.transfer_matrix.mult(x, temp)
-        v.vector().vec().aypx(0.0, temp)
+        self.transfer_matrix.mult(x, v.vector().vec())
         v.vector().apply("")
 
         return v


### PR DESCRIPTION
The PETScDMCollection can still be used with newer versions of PETSc / petsc4py. 
However, using `.createVecs` or similar cannot be done on the transfer matrix. The matrix can, however, still be multiplied, which is all we need.