### PR TITLE
Use the preinstalled conda for most of the CI runs

### DIFF
--- a/.github/workflows/conda_test.yml
+++ b/.github/workflows/conda_test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     
     steps:
-      - name: Update conda_test
+      - name: Update conda
         run: |
           conda update conda
       

--- a/.github/workflows/conda_test.yml
+++ b/.github/workflows/conda_test.yml
@@ -20,10 +20,10 @@ jobs:
           conda update conda
       
       - name: Install cashocs
-        run: conda create -n test -c conda-forge cashocs python=3.12 scotch"<7"
+        run: conda create -n cashocs -c conda-forge cashocs python=3.12 scotch"<7"
       
       - name: Test if package was installed properly
         run: |
-          conda run -n test python -c "import cashocs; cashocs.regular_mesh(16)"
-          conda run -n test mpirun -n 2 python -c "import cashocs; cashocs.regular_mesh(16)"
+          conda run -n cashocs python -c "import cashocs; cashocs.regular_mesh(16)"
+          conda run -n cashocs mpirun -n 2 python -c "import cashocs; cashocs.regular_mesh(16)"
         

--- a/.github/workflows/test_demos.yml
+++ b/.github/workflows/test_demos.yml
@@ -19,29 +19,24 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4.2.1
 
-    - name: Install micromamba
-      uses: mamba-org/setup-micromamba@v1
-      with:
-        environment-file: .github/micromamba/testenv.yml
-        create-args: >-
-          fenics=2019
-          meshio>=5.3
-          pytest
-          gmsh>=4.8
-          matplotlib
-          scipy
-          scotch<7
-          python=3.12
+    - name: Create conda environment
+      run: conda create -n cashocs -c conda-forge fenics=2019 meshio">=5.3" pytest gmsh">=4.8" matplotlib scipy scotch"<7" python=3.12
+
+    - name: Show conda info
+      run: conda info
+
+    - name: Show list of all installed packages
+      run: conda list
 
     - name: Install package
       run: |
-        pip install .[all]
+        conda run --live-stream -n cashocs pip install .[all]
     
     - name: Run demos
       env: 
         OMP_NUM_THREADS: 2
       run: |
-        python3 -m pytest -vv demos/test.py
+        conda run --live-stream -n cashocs python3 -m pytest -vv demos/test.py
 
         
         
@@ -58,27 +53,21 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4.2.1
 
-    - name: Install micromamba
-      uses: mamba-org/setup-micromamba@v1
-      with:
-        environment-file: .github/micromamba/testenv.yml
-        create-args: >-
-          fenics=2019
-          meshio>=5.3
-          pytest
-          gmsh>=4.8
-          mpich
-          matplotlib
-          scipy
-          scotch<7
-          python=3.12
+    - name: Create conda environment
+      run: conda create -n cashocs -c conda-forge fenics=2019 meshio">=5.3" pytest gmsh">=4.8" mpich matplotlib scipy scotch"<7" python=3.12
+
+    - name: Show conda info
+      run: conda info
+
+    - name: Show list of all installed packages
+      run: conda list
 
     - name: Install package
       run: |
-        pip install .[all]
+        conda run --live-stream -n cashocs pip install .[all]
         
     - name: Run demos in parallel
       env:
         OMP_NUM_THREADS: 1
       run: |
-        python3 -m pytest -vv demos/test_mpi.py
+        conda run --live-stream -n cashocs python3 -m pytest -vv demos/test_mpi.py

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -22,26 +22,22 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4.2.1
 
-    - name: Install micromamba
-      uses: mamba-org/setup-micromamba@v1
-      with:
-        environment-file: .github/micromamba/testenv.yml
-        create-args: >-
-          python=${{ matrix.python-version }}
-          fenics=2019
-          meshio>=5.3
-          pytest
-          gmsh>=4.8
-          scipy
-          scotch<7
+    - name: Create conda environment
+      run: conda create -n cashocs -c conda-forge python=${{ matrix.python-version }} fenics=2019 meshio">=5.3" pytest gmsh">=4.8" scipy scotch"<7"
+
+    - name: Show conda info
+      run: conda info
+
+    - name: Show list of all installed packages
+      run: conda list
 
     - name: Install package
       run: |
-        pip install .[all]
+        conda run --live-stream -n cashocs pip install .[all]
 
     - name: Run tests
       env: 
         OMP_NUM_THREADS: 2
       run: |
-        python3 -m pytest -vv tests/
+        conda run --live-stream -n cashocs python3 -m pytest -vv tests/
  

--- a/.github/workflows/tests_parallel.yml
+++ b/.github/workflows/tests_parallel.yml
@@ -26,26 +26,21 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4.2.1
 
-    - name: Install micromamba
-      uses: mamba-org/setup-micromamba@v1
-      with:
-        environment-file: .github/micromamba/testenv.yml
-        create-args: >-
-          fenics=2019
-          meshio>=5.3
-          pytest
-          gmsh>=4.8
-          scipy
-          scotch<7
-          ${{ matrix.mpi }}
-          python=${{ matrix.python-version }}
+    - name: Create conda environment
+      run: conda create -n cashocs -c conda-forge fenics=2019 meshio">=5.3" pytest gmsh">=4.8" scipy scotch"<7" ${{ matrix.mpi }} python=${{ matrix.python-version }}
+
+    - name: Show conda info
+      run: conda info
+
+    - name: Show list of all installed packages
+      run: conda list
 
     - name: Install package
       run: |
-        pip install .[all]
+        conda run --live-stream -n cashocs pip install .[all]
     
     - name: Run tests in parallel
       env: 
         OMP_NUM_THREADS: 1
       run: |
-        mpirun -n 2 python3 -m pytest -vv --timeout=1800 -p no:cacheprovider --randomly-seed=${{ github.run_id }} tests/
+        conda run --live-stream -n cashocs mpirun -n 2 python3 -m pytest -vv --timeout=1800 -p no:cacheprovider --randomly-seed=${{ github.run_id }} tests/

--- a/.github/workflows/tests_serial.yml
+++ b/.github/workflows/tests_serial.yml
@@ -24,17 +24,21 @@ jobs:
       uses: actions/checkout@v4.2.1
 
     - name: Create conda environment
-      run: |
-        conda create -n cashocs -c conda-forge fenics=2019 meshio">=5.3" pytest gmsh">=4.8" scipy scotch"<7" python=${{ matrix.python-version }}
-        conda list
+      run: conda create -n cashocs -c conda-forge fenics=2019 meshio">=5.3" pytest gmsh">=4.8" scipy scotch"<7" python=${{ matrix.python-version }}
+
+    - name: Show conda info
+      run: conda info
+
+    - name: Show list of all installed packages
+      run: conda list
 
     - name: Install package
       run: |
-        conda run -n cashocs pip install .[all]
+        conda run --live-stream -n cashocs pip install .[all]
 
     - name: Run tests
       env: 
         OMP_NUM_THREADS: 2
       run: |
-        conda run -n cashocs python3 -m pytest -vv tests/
+        conda run --live-stream -n cashocs python3 -m pytest -vv tests/
  

--- a/.github/workflows/tests_serial.yml
+++ b/.github/workflows/tests_serial.yml
@@ -23,6 +23,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4.2.1
 
+    - name: Create conda environment
+      run: |
+        conda create -n cashocs -c conda-forge fenics=2019 meshio">=5.3" pytest gmsh">=4.8" scipy scotch"<7" python=${{ matrix.python-version }}
+
     - name: Install micromamba
       uses: mamba-org/setup-micromamba@v1
       with:
@@ -38,11 +42,13 @@ jobs:
 
     - name: Install package
       run: |
+        conda activate cashocs
         pip install .[all]
 
     - name: Run tests
       env: 
         OMP_NUM_THREADS: 2
       run: |
+        conda activate cashocs
         python3 -m pytest -vv tests/
  

--- a/.github/workflows/tests_serial.yml
+++ b/.github/workflows/tests_serial.yml
@@ -26,16 +26,15 @@ jobs:
     - name: Create conda environment
       run: |
         conda create -n cashocs -c conda-forge fenics=2019 meshio">=5.3" pytest gmsh">=4.8" scipy scotch"<7" python=${{ matrix.python-version }}
+        conda list
 
     - name: Install package
       run: |
-        conda activate cashocs
-        pip install .[all]
+        conda run -n cashocs pip install .[all]
 
     - name: Run tests
       env: 
         OMP_NUM_THREADS: 2
       run: |
-        conda activate cashocs
-        python3 -m pytest -vv tests/
+        conda run -n cashocs python3 -m pytest -vv tests/
  

--- a/.github/workflows/tests_serial.yml
+++ b/.github/workflows/tests_serial.yml
@@ -27,19 +27,6 @@ jobs:
       run: |
         conda create -n cashocs -c conda-forge fenics=2019 meshio">=5.3" pytest gmsh">=4.8" scipy scotch"<7" python=${{ matrix.python-version }}
 
-    - name: Install micromamba
-      uses: mamba-org/setup-micromamba@v1
-      with:
-        environment-file: .github/micromamba/testenv.yml
-        create-args: >-
-          fenics=2019
-          meshio>=5.3
-          pytest
-          gmsh>=4.8
-          scipy
-          scotch<7
-          python=${{ matrix.python-version }}
-
     - name: Install package
       run: |
         conda activate cashocs


### PR DESCRIPTION
This provides a simpler interface to using conda with github actions, as it is preinstalled anyways.