### PR TITLE
Make the inner optimal control problem silent in topology optimization

### DIFF
--- a/cashocs/_optimization/optimal_control/optimal_control_problem.py
+++ b/cashocs/_optimization/optimal_control/optimal_control_problem.py
@@ -262,6 +262,7 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
                 self, self.box_constraints, self.db
             )
         )
+        self._silent = False
 
         if bool(desired_weights is not None):
             self._scale_cost_functional()
@@ -405,7 +406,8 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
                 + \texttt{rtol} || \nabla J(u_0) ||
 
         """
-        log.begin("Solving the optimal control problem.", level=log.INFO)
+        if not self._silent:
+            log.begin("Solving the optimal control problem.", level=log.INFO)
         super().solve(algorithm=algorithm, rtol=rtol, atol=atol, max_iter=max_iter)
 
         self._setup_control_bcs()
@@ -413,7 +415,8 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
         self.solver = self._setup_solver()
         self.solver.run()
         self.solver.post_processing()
-        log.end()
+        if not self._silent:
+            log.end()
 
     def compute_gradient(self) -> List[fenics.Function]:
         """Solves the Riesz problem to determine the gradient.

--- a/cashocs/_optimization/optimization_algorithms/optimization_algorithm.py
+++ b/cashocs/_optimization/optimization_algorithms/optimization_algorithm.py
@@ -244,7 +244,6 @@ class OptimizationAlgorithm(abc.ABC):
         """
         if self.soft_exit:
             log.error(message)
-            log.end()
         else:
             raise _exceptions.NotConvergedError("Optimization Algorithm", message)
 
@@ -269,6 +268,7 @@ class OptimizationAlgorithm(abc.ABC):
             elif self.converged_reason == -2:
                 self.iteration -= 1
                 self.post_process()
+                log.end()
                 self._exit("Armijo rule failed.")
 
             # Mesh Quality is too low

--- a/cashocs/_optimization/optimization_algorithms/optimization_algorithm.py
+++ b/cashocs/_optimization/optimization_algorithms/optimization_algorithm.py
@@ -244,6 +244,7 @@ class OptimizationAlgorithm(abc.ABC):
         """
         if self.soft_exit:
             log.error(message)
+            log.end()
         else:
             raise _exceptions.NotConvergedError("Optimization Algorithm", message)
 

--- a/cashocs/_optimization/topology_optimization/descent_topology_algorithm.py
+++ b/cashocs/_optimization/topology_optimization/descent_topology_algorithm.py
@@ -75,6 +75,9 @@ class DescentTopologyAlgorithm(
         self._cashocs_problem.config.set("OptimizationRoutine", "rtol", "0.0")
         self._cashocs_problem.config.set("OptimizationRoutine", "atol", "0.0")
 
+        self._cashocs_problem._silent = True
+        self._cashocs_problem.output_manager._silent = True
+
         self.successful = False
         self.loop_restart = False
 

--- a/cashocs/io/output.py
+++ b/cashocs/io/output.py
@@ -44,6 +44,8 @@ class OutputManager:
         self.result_dir = self.config.get("Output", "result_dir")
         self.result_dir = self.result_dir.rstrip("/")
 
+        self._silent = False
+
         self.time_suffix = self.config.getboolean("Output", "time_suffix")
         if self.time_suffix:
             dt_current_time = dt.now()
@@ -93,15 +95,18 @@ class OutputManager:
 
     def output(self) -> None:
         """Writes the desired output to files and console."""
-        for manager in self.managers:
-            manager.output()
+        if not self._silent:
+            for manager in self.managers:
+                manager.output()
 
     def output_summary(self) -> None:
         """Writes the summary to files and console."""
-        for manager in self.managers:
-            manager.output_summary()
+        if not self._silent:
+            for manager in self.managers:
+                manager.output_summary()
 
     def post_process(self) -> None:
         """Performs a postprocessing of the output."""
-        for manager in self.managers:
-            manager.post_process()
+        if not self._silent:
+            for manager in self.managers:
+                manager.post_process()


### PR DESCRIPTION
This PR fixes a bug with the new logging, see #513 

This is fixed by adding _silent attributes to the output manager and the (inner) optimal control problem which are set to True only if the problem is used as inner one for topology optimization.

Closes #513