### PR TITLE
Update python versions, drop support for python 3.8

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -18,7 +18,7 @@ RUN micromamba install -y -n base -c conda-forge \
       mpich \
       scipy \
       scotch"<7" \
-      python=3.11 && \
+      python=3.12 && \
    micromamba clean --all --yes
 
 ARG MAMBA_DOCKERFILE_ACTIVATE=1

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/tests_parallel.yml
+++ b/.github/workflows/tests_parallel.yml
@@ -16,11 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         mpi: [mpich, openmpi]
-        exclude:
-          - python-version: "3.8"
-            mpi: openmpi
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/tests_serial.yml
+++ b/.github/workflows/tests_serial.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout repository

--- a/cashocs/geometry/mesh_handler.py
+++ b/cashocs/geometry/mesh_handler.py
@@ -57,9 +57,10 @@ def _remove_gmsh_parametrizations(mesh_file: str) -> None:
     """
     temp_location = f"{mesh_file[:-4]}_temp.msh"
     if fenics.MPI.rank(fenics.MPI.comm_world) == 0:
-        with open(mesh_file, "r", encoding="utf-8") as in_file, open(
-            temp_location, "w", encoding="utf-8"
-        ) as temp_file:
+        with (
+            open(mesh_file, "r", encoding="utf-8") as in_file,
+            open(temp_location, "w", encoding="utf-8") as temp_file,
+        ):
             parametrizations_section = False
 
             for line in in_file:

--- a/cashocs/io/mesh.py
+++ b/cashocs/io/mesh.py
@@ -410,9 +410,10 @@ def parse_file(
         dim: The dimensionality of the mesh
 
     """
-    with open(original_msh_file, "r", encoding="utf-8") as old_file, open(
-        out_msh_file, "w", encoding="utf-8"
-    ) as new_file:
+    with (
+        open(original_msh_file, "r", encoding="utf-8") as old_file,
+        open(out_msh_file, "w", encoding="utf-8") as new_file,
+    ):
         node_section = False
         info_section = False
         subnode_counter = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "cashocs"
 version = "2.3.0"
 description = "Computational Adjoint-Based Shape Optimization and Optimal Control Software"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = {text = "GNU General Public License v3 or later (GPLv3+)"}
 authors = [
 	{name = "Sebastian Blauth"},
@@ -34,7 +34,6 @@ classifiers = [
     "Intended Audience :: End Users/Desktop",
     "Intended Audience :: Science/Research",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
With the end of life of python 3.8, support for it is dropped.