### PR TITLE
Add info log and timing for the snes solver

### DIFF
--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -223,6 +223,7 @@ class SNESSolver:
 
     def solve(self) -> fenics.Function:
         """Solves the nonlinear problem with PETSc's SNES."""
+        log.begin("Solving the nonlinear PDE system with PETSc SNES.")
         snes = PETSc.SNES().create()
 
         snes.setFunction(self.assemble_function, self.residual_petsc)
@@ -249,6 +250,8 @@ class SNESSolver:
             snes.destroy()
             PETSc.garbage_cleanup(comm=self.comm)
             PETSc.garbage_cleanup()
+
+        log.end()
 
         return self.u
 


### PR DESCRIPTION
This PR adds two log calls for noting the start and end of the PETSc SNES solver for nonlinear problems, analogously to what's done in `cashocs.newton_solve`