### PR TITLE
Support measure indexing by name, i.e., `ds("inlet")` and `ds(["wall", "outlet"])`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ here as they add new functionality or might change the API. For a documentation
 of the maintenance releases, please take a look at
 `<https://github.com/sblauth/cashocs/releases>`_.
 
+2.4.0 (in development)
+----------------------
+
+* Add support for named Gmsh meshes, so that the names can not only be used with :py:func:`cashocs.create_dirichlet_bcs`, but also with the :py:class:`cashocs.NamedMeasure` objects created with :py:func:`cashocs.import_mesh`.
+
 2.3.0 (November 12, 2024)
 -------------------------
 

--- a/cashocs/geometry/measure.py
+++ b/cashocs/geometry/measure.py
@@ -76,7 +76,7 @@ class _EmptyMeasure(ufl.Measure):
 
 
 def generate_measure(
-    idx: List[int], measure: fenics.Measure
+    idx: List[Union[int, str]], measure: fenics.Measure
 ) -> Union[fenics.Measure, _EmptyMeasure]:
     """Generates a measure based on indices.
 
@@ -195,8 +195,8 @@ class NamedMeasure(ufl.Measure):
                 rule=rule,
             )
 
-        elif isinstance(subdomain_id, (list)) and all(
-            isinstance(x, int) for x in subdomain_id
+        elif isinstance(subdomain_id, list) and all(
+            isinstance(x, (int, str)) for x in subdomain_id
         ):
             return generate_measure(subdomain_id, self)
 


### PR DESCRIPTION
This PR adds support for indexing NamedMeasures with names from the Gmsh mesh file.