### PR TITLE
Update the OS versions to the latest ones where possible

### DIFF
--- a/.github/workflows/conda_test.yml
+++ b/.github/workflows/conda_test.yml
@@ -10,7 +10,7 @@ jobs:
     name: Test conda installation
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/conda_test.yml
+++ b/.github/workflows/conda_test.yml
@@ -10,7 +10,7 @@ jobs:
     name: Test conda installation
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-latest, macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -8,8 +8,8 @@ on:
     
 jobs:
   serial_tests:
-    name: Test (py=${{ matrix.python-version}}, macos-12)
-    runs-on: macos-12
+    name: Test (py=${{ matrix.python-version}}, macos-latest)
+    runs-on: macos-latest
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -8,8 +8,8 @@ on:
     
 jobs:
   serial_tests:
-    name: Test (py=${{ matrix.python-version}}, macos-latest)
-    runs-on: macos-latest
+    name: Test (py=${{ matrix.python-version}}, macos-13)
+    runs-on: macos-13
     defaults:
       run:
         shell: bash -el {0}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.11"
 


### PR DESCRIPTION
This is required as macos-12 is deprecated, see https://github.com/actions/runner-images/issues/10721