### PR TITLE
Fix `save_mesh` parameter for space mapping

### DIFF
--- a/cashocs/io/managers.py
+++ b/cashocs/io/managers.py
@@ -327,17 +327,27 @@ class MeshManager(IOManager):
         """Saves the mesh as checkpoint for each iteration."""
         iteration = int(self.db.parameter_db.optimization_state["iteration"])
 
+        if not self.db.parameter_db.gmsh_file_path:
+            gmsh_file = self.config.get("Mesh", "gmsh_file")
+        else:
+            gmsh_file = self.db.parameter_db.gmsh_file_path
+
         iomesh.write_out_mesh(
             self.db.geometry_db.mesh,
-            self.db.parameter_db.gmsh_file_path,
+            gmsh_file,
             f"{self.result_dir}/checkpoints/mesh/mesh_{iteration}.msh",
         )
 
     def post_process(self) -> None:
         """Saves a copy of the optimized mesh in Gmsh format."""
+        if not self.db.parameter_db.gmsh_file_path:
+            gmsh_file = self.config.get("Mesh", "gmsh_file")
+        else:
+            gmsh_file = self.db.parameter_db.gmsh_file_path
+
         iomesh.write_out_mesh(
             self.db.function_db.states[0].function_space().mesh(),
-            self.db.parameter_db.gmsh_file_path,
+            gmsh_file,
             f"{self.result_dir}/optimized_mesh.msh",
         )
 


### PR DESCRIPTION
This PR modifies the behavior of the `MeshManager` to fall back to the gmsh_file provided in the configuration, if this has not been set by the `_MeshHandler` (which needs to do so for remeshing).

Closes #534 