### PR TITLE
Allow strings for lists in the config files

### DIFF
--- a/cashocs/io/config.py
+++ b/cashocs/io/config.py
@@ -63,7 +63,12 @@ def _check_for_config_list(string: str) -> bool:
     result = False
 
     for char in string:
-        if not (char.isdigit() or char.isspace() or char in ["[", "]", ".", ",", "-"]):
+        if not (
+            char.isdigit()
+            or char.isalpha()
+            or char.isspace()
+            or char in ["[", "]", ".", ",", "-", '"', "_"]
+        ):
             return result
 
     if string[0] != "[":
@@ -71,9 +76,7 @@ def _check_for_config_list(string: str) -> bool:
     if string[-1] != "]":
         return result
 
-    result = True
-
-    return result
+    return True
 
 
 class Config(ConfigParser):

--- a/cashocs/io/config.py
+++ b/cashocs/io/config.py
@@ -67,7 +67,7 @@ def _check_for_config_list(string: str) -> bool:
             char.isdigit()
             or char.isalpha()
             or char.isspace()
-            or char in ["[", "]", ".", ",", "-", '"', "_"]
+            or char in ["[", "]", ".", ",", "-", '"', "'", "_"]
         ):
             return result
 


### PR DESCRIPTION
This PR adds support for naming, e.g., `shape_bdry_def = ["wall"]`. 
Allowed characters are

- Quotation marks (both single `'` and double `"`) - these are needed to define strings
- Underscore `_`
- letters
- digits (these were allowed previously, too)
- `.` and `,`
- `-`