### PR TITLE
Interpolate CR functions to the corresponding DG space for XDMF output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,9 @@ of the maintenance releases, please take a look at
 2.5.0 (in development)
 ----------------------
 
-* Add support for Python 3.13
+* Add support for Python 3.13.
+
+* Functions with Crouzeix-Raviart elements are now interpolated into discontinuous Galerkin FEM spaces before being saved as .xdmf file so that they can be worked with.
 
 
 

--- a/cashocs/io/managers.py
+++ b/cashocs/io/managers.py
@@ -637,6 +637,16 @@ class XDMFFileManager(IOManager):
                 space = fenics.FunctionSpace(mesh, "CG", 1)
             function = fenics.interpolate(function, space)
 
+        elif function.function_space().ufl_element().family() == "Crouzeix-Raviart":
+            degree = function.function_space().ufl_element().degree()
+            if len(function.ufl_shape) > 0:
+                space = fenics.VectorFunctionSpace(
+                    mesh, "DG", degree, dim=function.ufl_shape[0]
+                )
+            else:
+                space = fenics.FunctionSpace(mesh, "DG", degree)
+            function = fenics.interpolate(function, space)
+
         function.rename(function_name, function_name)
 
         with fenics.XDMFFile(comm, filename) as file:


### PR DESCRIPTION
This PR ensures that Crouzeix-Raviart elements are treated "correctly" for the XDMF output - i.e., they are interpolated into the corresponding discontinuous Galerkin space before being saved as .xdmf file.