### PR TITLE
Make the log.begin / log.end bracket end before the solvers raise exceptions

### DIFF
--- a/cashocs/nonlinear_solvers/newton_solver.py
+++ b/cashocs/nonlinear_solvers/newton_solver.py
@@ -329,9 +329,8 @@ class _NewtonSolver:
             if self._check_for_convergence():
                 break
 
-        self._check_if_successful()
-
         log.end()
+        self._check_if_successful()
 
         return self.u
 

--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -251,6 +251,8 @@ class SNESSolver:
         self.u.vector().vec().setArray(x.vector().vec())
         self.u.vector().apply("")
 
+        log.end()
+
         converged_reason = snes.getConvergedReason()
         if converged_reason < 0:
             raise _exceptions.PETScSNESError(converged_reason)
@@ -259,8 +261,6 @@ class SNESSolver:
             snes.destroy()
             PETSc.garbage_cleanup(comm=self.comm)
             PETSc.garbage_cleanup()
-
-        log.end()
 
         return self.u
 

--- a/cashocs/nonlinear_solvers/ts.py
+++ b/cashocs/nonlinear_solvers/ts.py
@@ -481,6 +481,8 @@ class TSPseudoSolver:
         self.u.vector().vec().aypx(0.0, x.vector().vec())
         self.u.vector().apply("")
 
+        log.end()
+
         converged_reason = ts.getConvergedReason()
         if (
             converged_reason < 0
@@ -492,8 +494,6 @@ class TSPseudoSolver:
             ts.destroy()
             PETSc.garbage_cleanup(comm=self.comm)
             PETSc.garbage_cleanup()
-
-        log.end()
 
         return self.u
 


### PR DESCRIPTION
This fixes a bug which keeps indenting the logging messages in the line search if solving the state system fails.