### PR TITLE
Allow re-extending the gradient deformation for shape optimization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,9 +10,19 @@ of the maintenance releases, please take a look at
 2.5.0 (in development)
 ----------------------
 
+* Add the possibility to re-compute the gradient deformation in shape optimization. To do so, the gradient deformation is first computed as before but then only the surface deformation (or the one in normal direction) is used as boundary condition for the elasticty equation to compute a new deformation. This can help to avoid numerical artifacts in the interior of the domain not related to the actual shape changes.
+
 * Add support for Python 3.13.
 
 * Functions with Crouzeix-Raviart elements are now interpolated into discontinuous Galerkin FEM spaces before being saved as .xdmf file so that they can be worked with.
+
+* New configuration file parameters:
+
+  * Section ShapeGradient
+
+    * :ini:`reextend_from_boundary` is a boolean flag which indicates whether the gradient deformation should be re-computed as described above
+
+    * :ini:`reextension_mode` can have the values :ini:`reextension_mode = surface` or :ini:`reextension_mode = normal`. In the first case, the boundary values of the gradient deformation are used as they are for the re-extension, in the second case only the normal deformation is used.
 
 
 

--- a/cashocs/_forms/shape_form_handler.py
+++ b/cashocs/_forms/shape_form_handler.py
@@ -40,6 +40,8 @@ from cashocs._forms import shape_regularization
 from cashocs.geometry import boundary_distance
 
 if TYPE_CHECKING:
+    from petsc4py import PETSc
+
     try:
         from ufl_legacy.core import expr as ufl_expr
     except ImportError:
@@ -247,6 +249,7 @@ class ShapeFormHandler(form_handler.FormHandler):
     shape_derivative: ufl.Form
     fixed_indices: list[int]
     assembler: fenics.SystemAssembler
+    assembler_extension: fenics.SystemAssembler
     scalar_product_matrix: fenics.PETScMatrix
     modified_scalar_product: ufl.Form
 
@@ -354,8 +357,8 @@ class ShapeFormHandler(form_handler.FormHandler):
                 self.riesz_scalar_product, zero_source, self.bcs_extension
             )
             self.fe_reextension_matrix = fenics.PETScMatrix()
-            self.reextension_matrix = self.fe_reextension_matrix.mat()
-            self.fe_reextension_vector = fenics.PETScVector()
+            self.reextension_matrix: PETSc.Mat = self.fe_reextension_matrix.mat()
+            self.fe_reextension_vector: fenics.PETScVector = fenics.PETScVector()
 
         self.update_scalar_product()
         self.p_laplace_form = self._compute_p_laplacian_forms()

--- a/cashocs/_forms/shape_form_handler.py
+++ b/cashocs/_forms/shape_form_handler.py
@@ -817,3 +817,21 @@ class ShapeFormHandler(form_handler.FormHandler):
                 [0.0] * len(self.fixed_indices)
             )
             function.vector().apply("")
+
+    def apply_reextension_bcs(self, function: fenics.Function) -> None:
+        """Applies the boundary conditions for the reextension of the shape gradient.
+
+        Args:
+            function (fenics.Function): The function which shall receive the boundary
+                values of the shape gradient.
+
+        """
+        for bc in self.bcs_extension:
+            bc.apply(function.vector())
+            function.vector().apply("")
+
+        if self.use_fixed_dimensions:
+            function.vector().vec()[self.fixed_indices] = np.array(
+                [0.0] * len(self.fixed_indices)
+            )
+            function.vector().apply("")

--- a/cashocs/_pde_problems/shape_gradient_problem.py
+++ b/cashocs/_pde_problems/shape_gradient_problem.py
@@ -233,11 +233,21 @@ class ShapeGradientProblem(pde_problem.PDEProblem):
                 + "or 'shared_vertex' before importing your mesh."
             )
 
+        physical_groups = None
+        if hasattr(mesh, "physical_groups"):
+            physical_groups = mesh.physical_groups
+
         ds = measure.NamedMeasure(
-            "ds", domain=mesh, subdomain_data=self.form_handler.boundaries
+            "ds",
+            domain=mesh,
+            subdomain_data=self.form_handler.boundaries,
+            physical_groups=physical_groups,
         )
         dS = measure.NamedMeasure(  # pylint: disable=invalid-name
-            "dS", domain=mesh, subdomain_data=self.form_handler.boundaries
+            "dS",
+            domain=mesh,
+            subdomain_data=self.form_handler.boundaries,
+            physical_groups=physical_groups,
         )
 
         n = fenics.FacetNormal(mesh)

--- a/cashocs/io/config.py
+++ b/cashocs/io/config.py
@@ -394,6 +394,13 @@ class Config(ConfigParser):
                 "test_for_intersections": {
                     "type": "bool",
                 },
+                "reextend_from_boundary": {
+                    "type": "bool",
+                },
+                "reextension_mode": {
+                    "type": "str",
+                    "possible_options": ["surface", "normal"],
+                },
             },
             "Regularization": {
                 "factor_volume": {
@@ -634,6 +641,8 @@ shape_bdry_fix_z = []
 degree_estimation = True
 global_deformation = False
 test_for_intersections = True
+reextend_from_boundary = False
+reextension_mode = surface
 
 [Regularization]
 factor_volume = 0.0

--- a/docs/source/user/demos/shape_optimization/doc_config.rst
+++ b/docs/source/user/demos/shape_optimization/doc_config.rst
@@ -802,6 +802,30 @@ We have the parameter :ini:`test_for_intersections`, which is specified via
 If this parameter is set to `True`, cashocs will check the deformed meshes for (self) intersections, which would generate non-physical geometries and reject them - so that all generated designs are physically meaningful. This should not be set to `False`.
 
 
+The following two parameters are related to the re-extension of the gradient deformation. For this, cashocs first computes the gradient deformation
+as usual (and specified in the configuration file). Afterwards, only the surface deformation of the gradient is used to re-compute / re-extend this
+to the entire domain. To enable this behavior, the following parameter is used
+
+.. code-block:: ini
+
+    reextend_from_boundary = False
+
+The default value of this parameter is `False`, so that the gradient deformation is not re-extended. If this is set to `True`, the parameter
+
+.. code-block:: ini
+
+    reextension_mode = surface
+
+specifies, how the gradient deformation is re-extended. If this is :ini:`reextension_mode = surface` (the default), then the surface values of the
+gradient deformation are used as they are. If this is :ini:`reextension_mode = normal`, only the normal component of the gradient deformation is used
+as information for the re-extension.
+
+.. note::
+
+    Using the re-extension of the gradient deformation might improve the shape optimization, particularly if there are artifacts in the interior of
+    the domain not related to any shape changes. However, using this approach does change the gradient - so the deformation might also be suboptimal.
+
+
 .. _config_shape_regularization:
 
 Section Regularization


### PR DESCRIPTION
This PR allows to re-compute / re-extend the gradient deformation based on its values on the surfaces. 

Closes #626 