### PR TITLE
Updates to `ts_pseudo_solve`: divergence tolerance and convergence after maximum iterations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ of the maintenance releases, please take a look at
 2.5.0 (in development)
 ----------------------
 
+* Update the way :py:func:`cashocs.ts_pseudo_solve` handles convergence / divergence. A new divergence tolerance is introduced. If the residual increases by a factor of 1e4, the solver automatically diverges and raises a corresponding exception. Moreover, if the solver reaches the maximum number of iterations, no exception is raised anymore. Instead, a warning is issued that the solver did not reach the specified tolerances, but converges anyway. This is in line with the convergence of the PETSc TS.
+
 * Add support for Python 3.13.
 
 * Functions with Crouzeix-Raviart elements are now interpolated into discontinuous Galerkin FEM spaces before being saved as .xdmf file so that they can be worked with.

--- a/cashocs/_exceptions.py
+++ b/cashocs/_exceptions.py
@@ -192,11 +192,11 @@ class PETScTSError(PETScError):
         """
         super().__init__(error_code, message)
         self.error_dict = {
-            2: " (ts_converged_its)",
             -1: " (ts_diverged_nonlinear_solve)",
             -2: " (ts_diverged_step_rejected)",
             -3: " (ts_forward_diverged_linear_solve)",
             -4: " (ts_adjoint_diverged_linear_solve)",
+            -5: " (ts_diverged_dtol, reached divergence tolerance)",
         }
 
 

--- a/cashocs/nonlinear_solvers/ts.py
+++ b/cashocs/nonlinear_solvers/ts.py
@@ -411,9 +411,14 @@ class TSPseudoSolver:
         """
         self.res_current = self.compute_nonlinear_residual(u)
 
+        if self.res_initial == 0:
+            relative_residual = self.res_current
+        else:
+            relative_residual = self.res_current / self.res_initial
+
         log.debug(
             f"TS {i = }  {t = :.3e}  "
-            f"residual: {self.res_current / self.res_initial:.3e} (rel)  "
+            f"residual: {relative_residual:.3e} (rel)  "
             f"{self.res_current:.3e} (abs)"
         )
 


### PR DESCRIPTION
This PR adds the following features to the `ts_pseudo_solve`

- Add divergence test, with default divergence tolerance of 1e4. At the moment, only the default can be used, as petsc4py can access the `SNES.getDivergenceTolerance()` method only for petsc4py > 3.20
- If the maximum number of iterations has been reached, the solver does not diverge and raise an exception anymore. Instead, a warning is issued with the current (relative and absolute) residual and the tolerances, indicating that the solver may not be converged. This is in line with the behavior of the PETSc TS objects.

Closes #630 