### PR TITLE
Add possiblity to use adjoint linearization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,14 @@ of the maintenance releases, please take a look at
 2.6.0 (in development)
 ----------------------
 
+* Add the possibility to use the adjoint form of the user-provided `newton_linearizations`: For example, if a Picard iteration is used to solve the nonlinear state system, then the adjoint of the Picard linearization can be used to solve the adjoint system. This may require more "nonlinear" or defect-correction iterations, but may yield linear systems that are significatly easier to solve. This is controlled with the configuration parameter :ini:`use_adjoint_linearizations` in the Section StateSystem.
+
+* New configuration file parameters:
+
+  * Section StateSystem
+
+    * :ini:`use_adjoint_linearizations` is a boolean flag which specifies, whether or not the adjoint form of the `newton_linearizations` should be used to solve the adjoint system.
+
 
 
 2.5.0 (March 26, 2025)

--- a/cashocs/_database/parameter_database.py
+++ b/cashocs/_database/parameter_database.py
@@ -55,10 +55,6 @@ class ParameterDatabase:
         self.state_ksp_options = state_ksp_options
         self.adjoint_ksp_options = adjoint_ksp_options
 
-        if self.adjoint_ksp_options is not None:
-            for opt in self.adjoint_ksp_options:
-                opt["snes_type"] = "ksponly"
-
         self.gradient_ksp_options = gradient_ksp_options
         self.temp_dict: dict = {}
 

--- a/cashocs/_pde_problems/adjoint_problem.py
+++ b/cashocs/_pde_problems/adjoint_problem.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import fenics
+import ufl
 
 from cashocs import _utils
 from cashocs import log
@@ -43,6 +44,7 @@ class AdjointProblem(pde_problem.PDEProblem):
         adjoint_form_handler: _forms.AdjointFormHandler,
         state_problem: sp.StateProblem,
         linear_solver: _utils.linalg.LinearSolver | None = None,
+        adjoint_linearizations: list[ufl.Form] | None = None,
     ) -> None:
         """Initializes self.
 
@@ -53,6 +55,8 @@ class AdjointProblem(pde_problem.PDEProblem):
                 linearize the problem.
             linear_solver: The linear solver (KSP) which is used to solve the linear
                 systems arising from the discretized PDE.
+            adjoint_linearizations: The UFL form of the linearization to be employed for
+                solving the adjoint system. Defaults to None.
 
         """
         super().__init__(db, linear_solver=linear_solver)
@@ -63,6 +67,10 @@ class AdjointProblem(pde_problem.PDEProblem):
         self.excluded_from_time_derivative = (
             self.state_problem.excluded_from_time_derivative
         )
+        if adjoint_linearizations is not None:
+            self.adjoint_linearizations = adjoint_linearizations
+        else:
+            self.adjoint_linearizations = [None] * self.db.parameter_db.state_dim
 
         self.adjoints = self.db.function_db.adjoints
         self.bcs_list_ad = self.adjoint_form_handler.bcs_list_ad
@@ -138,6 +146,7 @@ class AdjointProblem(pde_problem.PDEProblem):
                             self.adjoint_form_handler.adjoint_eq_forms[-1 - i],
                             self.adjoints[-1 - i],
                             self.bcs_list_ad[-1 - i],
+                            derivative=self.adjoint_linearizations[-1 - i],
                             petsc_options=self.db.parameter_db.adjoint_ksp_options[
                                 -1 - i
                             ],
@@ -147,6 +156,23 @@ class AdjointProblem(pde_problem.PDEProblem):
                                 -1 - i
                             ],
                             excluded_from_time_derivative=eftd,
+                        )
+                    elif self.db.config.getboolean(
+                        "StateSystem", "use_adjoint_linearizations"
+                    ):
+                        nonlinear_solvers.snes_solve(
+                            self.adjoint_form_handler.adjoint_eq_forms[-1 - i],
+                            self.adjoints[-1 - i],
+                            self.bcs_list_ad[-1 - i],
+                            derivative=self.adjoint_linearizations[-1 - i],
+                            petsc_options=self.db.parameter_db.adjoint_ksp_options[
+                                -1 - i
+                            ],
+                            A_tensor=self.A_tensors[-1 - i],
+                            b_tensor=self.b_tensors[-1 - i],
+                            preconditioner_form=self.db.form_db.preconditioner_forms[
+                                -1 - i
+                            ],
                         )
                     else:
                         _utils.assemble_and_solve_linear(
@@ -180,6 +206,7 @@ class AdjointProblem(pde_problem.PDEProblem):
                     A_tensors=self.A_tensors[::-1],
                     b_tensors=self.b_tensors[::-1],
                     preconditioner_forms=self.db.form_db.preconditioner_forms[::-1],
+                    newton_linearizations=self.adjoint_linearizations[::-1],
                 )
 
             self.has_solution = True

--- a/cashocs/io/config.py
+++ b/cashocs/io/config.py
@@ -159,6 +159,9 @@ class Config(ConfigParser):
                     "type": "str",
                     "possible_options": ["cashocs", "petsc"],
                 },
+                "use_adjoint_linearizations": {
+                    "type": "bool",
+                },
             },
             "OptimizationRoutine": {
                 "algorithm": {
@@ -590,6 +593,7 @@ picard_atol = 1e-12
 picard_iter = 50
 picard_verbose = False
 backend = cashocs
+use_adjoint_linearizations = False
 
 [OptimizationRoutine]
 algorithm = none

--- a/docs/source/user/demos/optimal_control/doc_config.rst
+++ b/docs/source/user/demos/optimal_control/doc_config.rst
@@ -174,6 +174,19 @@ is used which can be configured with the `ksp_options` supplied by the user to t
 :py:class:`cashocs.OptimizationProblem`. An overview over possible PETSc command line options
 can be found at `<https://petsc.org/release/manualpages/SNES/>`_.
 
+The parameter :ini:`use_adjoint_linearizations` is a boolean which specifies whether the adjoint form
+of the linearization provided with `newton_linearizations` should be used to solve the adjoint equation.
+The parameter is set with the line
+
+.. code-block:: ini
+
+    use_adjoint_linearizations = False
+
+The default value is `False`. Note that one has to use a PETSc SNES solver (or pseudo time stepping)
+in order for this to make sense. Using the option `-snes_type ksponly` with the SNES solver will not
+give correct results (if the provided linearization is not the Newton linearization). The benefit of
+doing so can be significantly easier to solve linear systems at the cost of doing more "nonlinear"
+iterations, in a defect-correction setting.
 
 
 
@@ -660,6 +673,8 @@ in the following.
       - :ini:`picard_verbose = True` enables verbose output of Picard iteration
     * - :ini:`backend = cashocs`
       - specifies the backend for solving nonlinear equations, can be either :ini:`cashocs` or :ini:`petsc`
+    * - :ini:`use_adjoint_linearizations = False`
+      - if `True`, the adjoint form of the provided `newton_linearizations` will be used for the adjoint system.
 
 [OptimizationRoutine]
 *********************

--- a/docs/source/user/demos/shape_optimization/doc_config.rst
+++ b/docs/source/user/demos/shape_optimization/doc_config.rst
@@ -230,6 +230,19 @@ is used which can be configured with the `ksp_options` supplied by the user to t
 :py:class:`cashocs.OptimizationProblem`. An overview over possible PETSc command line options
 can be found at `<https://petsc.org/release/manualpages/SNES/>`_.
 
+The parameter :ini:`use_adjoint_linearizations` is a boolean which specifies whether the adjoint form
+of the linearization provided with `newton_linearizations` should be used to solve the adjoint equation.
+The parameter is set with the line
+
+.. code-block:: ini
+
+    use_adjoint_linearizations = False
+
+The default value is `False`. Note that one has to use a PETSc SNES solver (or pseudo time stepping)
+in order for this to make sense. Using the option `-snes_type ksponly` with the SNES solver will not
+give correct results (if the provided linearization is not the Newton linearization). The benefit of
+doing so can be significantly easier to solve linear systems at the cost of doing more "nonlinear"
+iterations, in a defect-correction setting.
 
 .. _config_shape_optimization_routine:
 
@@ -1225,6 +1238,8 @@ in the following.
       - :ini:`picard_verbose = True` enables verbose output of Picard iteration
     * - :ini:`backend = cashocs`
       - specifies the backend for solving nonlinear equations, can be either :ini:`cashocs` or :ini:`petsc`
+    * - :ini:`use_adjoint_linearizations = False`
+      - if `True`, the adjoint form of the provided `newton_linearizations` will be used for the adjoint system.
 
 
 


### PR DESCRIPTION
This PR introduces a new config file parameter `use_adjoint_linearizations` in the section StateSystem. This is used to employ the adjoint form of the newton_linearizations (if they are provided by the user) for solving the adjoint system (in a defect-correction sense). 

Closes #659 