### PR TITLE
Fix a bug where logging did not indent correctly

### DIFF
--- a/cashocs/_pde_problems/state_problem.py
+++ b/cashocs/_pde_problems/state_problem.py
@@ -268,3 +268,5 @@ class StateProblem(pde_problem.PDEProblem):
                 0.0, self.states_checkpoint[i].vector().vec()
             )
             self.states[i].vector().apply("")
+
+        log.end()


### PR DESCRIPTION
This PR fixes a bug where the log continued to indent if the state problem failed to converge. 