### PR TITLE
`cashocs.io.import_function` does not require the parameter `name` anymore

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ of the maintenance releases, please take a look at
 
 * The mesh conversion routines now only produce two .xdmf and .h5 files instead of three to save disk space. For mesh files converted with earlier versions of cashocs, the import still works and correctly recognizes the "_subdomains.xdmf" file. Converting and importing a mesh otherwise works as before, so users should not notice any difference.
 
+* Changed the way :py:func:`cashocs.io.import_function` works: Now, the name of the saved function is taken automatically. As cashocs one saves one function per .xdmf file, this should not change any workflows. Users can (and must) still specify a name in case multiple functions are saved in a single file.
+
 * New configuration file parameters:
 
   * Section StateSystem

--- a/cashocs/io/function.py
+++ b/cashocs/io/function.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 import fenics
 import h5py
 
+from cashocs import _exceptions
 from cashocs.io import mesh as mesh_io
 
 if TYPE_CHECKING:
@@ -102,7 +103,16 @@ def import_function(
     h5_path = file_path.with_suffix(".h5")
     if name is None:
         with h5py.File(str(h5_path), "r") as f:
-            name = list(f.keys())[0]
+            names = list(f.keys())
+            if len(names) == 1:
+                name = names[0]
+            else:
+                raise _exceptions.InputError(
+                    "import_function",
+                    "name",
+                    "You did not specify a name for importing the function. "
+                    f"Available keys are {names}.",
+                )
 
     with fenics.XDMFFile(comm, filename) as file:
         file.read_checkpoint(function, name, step)


### PR DESCRIPTION
When using `cashocs.io.import_mesh`, the parameter `name` is now optional. In case only one function is saved in the .xdmf file, the name is inferred automatically. 
In case more than one function is saved, an exception is raised which lists the potential names.

Closes #642 