### PR TITLE
Add the possibility to compute the mesh quality based on quantiles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,11 +20,17 @@ of the maintenance releases, please take a look at
 
 * Two additional demos have been added which describe how custom MPI communicators can be used with cashocs. They can be found at `<https://cashocs.readthedocs.io/en/stable/user/demos/misc/demo_mpi_comm_self/>`_ and `<https://cashocs.readthedocs.io/en/stable/user/demos/misc/demo_mpi_custom/>`_.
 
+* Add the possibility to compute the mesh quality based on a quantile. This can be useful for remeshing, where the minimum approach is too strict and the maximum approach too coarse.
+
 * New configuration file parameters:
 
   * Section StateSystem
 
     * :ini:`use_adjoint_linearizations` is a boolean flag which specifies, whether or not the adjoint form of the `newton_linearizations` should be used to solve the adjoint system.
+
+  * Section MeshQuality
+
+    * :ini:`quantile` is a user-specified quantile for which the mesh quality is computed. For example, :ini:`quantile = 0.5` uses the median mesh quality.
 
 
 

--- a/cashocs/geometry/mesh_handler.py
+++ b/cashocs/geometry/mesh_handler.py
@@ -138,9 +138,13 @@ class _MeshHandler:
         self.mesh_quality_measure = self.config.get("MeshQuality", "measure")
 
         self.mesh_quality_type = self.config.get("MeshQuality", "type")
+        self.quality_quantile = self.config.getfloat("MeshQuality", "quantile")
 
         self.current_mesh_quality: float = quality.compute_mesh_quality(
-            self.mesh, self.mesh_quality_type, self.mesh_quality_measure
+            self.mesh,
+            quality_type=self.mesh_quality_type,
+            quality_measure=self.mesh_quality_measure,
+            quantile=self.quality_quantile,
         )
 
         if not self.db.parameter_db.is_remeshed:
@@ -286,7 +290,10 @@ class _MeshHandler:
                 test_for_intersections=self.test_for_intersections,
             )
             self.current_mesh_quality = quality.compute_mesh_quality(
-                self.mesh, self.mesh_quality_type, self.mesh_quality_measure
+                self.mesh,
+                quality_type=self.mesh_quality_type,
+                quality_measure=self.mesh_quality_measure,
+                quantile=self.quality_quantile,
             )
             if success_flag:
                 log.debug(
@@ -616,13 +623,15 @@ class _MeshHandler:
 
         mesh_quality_measure = self.db.config.get("MeshQuality", "measure")
         mesh_quality_type = self.db.config.get("MeshQuality", "type")
+        quality_quantile = self.db.config.getfloat("MeshQuality", "quantile")
 
         mesh = solver.optimization_problem.states[0].function_space().mesh()
 
         current_mesh_quality = quality.compute_mesh_quality(
             mesh,
-            mesh_quality_type,
-            mesh_quality_measure,
+            quality_type=mesh_quality_type,
+            quality_measure=mesh_quality_measure,
+            quantile=quality_quantile,
         )
 
         check_mesh_quality_tolerance(current_mesh_quality, mesh_quality_tol_upper)

--- a/cashocs/geometry/quality.py
+++ b/cashocs/geometry/quality.py
@@ -55,9 +55,9 @@ def compute_mesh_quality(
         quantile: The quantile which shall be used to compute the mesh quality.
 
     Notes:
-        One can specify a quantile when using :py:`quality_type="quantile"` and
-        specifying :py:`quantile=q`, where :math:`q \in [0,1]` is some probability for
-        the quantile to compute. That means that the computed quality
+        One can specify a quantile when using :python:`quality_type="quantile"` and
+        specifying :python:`quantile=q`, where :math:`q \in [0,1]` is some probability
+        for the quantile to compute. That means that the computed quality
         :math:`Q \in [0,1]` satisfies the following relation: :math:`100q \%` of all
         mesh cells have a quality lower than :math:`Q`, whereas :math:`100(1-q) \%` of
         all mesh cells have a quality greater than :math:`Q`. In particular,

--- a/cashocs/io/config.py
+++ b/cashocs/io/config.py
@@ -496,7 +496,18 @@ class Config(ConfigParser):
                 },
                 "type": {
                     "type": "str",
-                    "possible_options": ["min", "avg", "minimum", "average"],
+                    "possible_options": [
+                        "min",
+                        "avg",
+                        "q",
+                        "minimum",
+                        "average",
+                        "quantile",
+                    ],
+                },
+                "quantile": {
+                    "type": "float",
+                    "attributes": ["non_negative", "less_than_one"],
                 },
                 "remesh_iter": {
                     "type": "int",
@@ -691,6 +702,7 @@ tol_lower = 0.0
 tol_upper = 1e-15
 measure = skewness
 type = min
+quantile = 0.0
 volume_change = inf
 angle_change = inf
 remesh_iter = 0

--- a/docs/source/user/demos/shape_optimization/doc_config.rst
+++ b/docs/source/user/demos/shape_optimization/doc_config.rst
@@ -1057,15 +1057,25 @@ Available options are
 (see :py:class:`MeshQuality <cashocs.MeshQuality>` for a detailed description).
 The default value is given by :ini:`measure = skewness`.
 
-The parameter :ini:`type` determines, whether the minimum quality over all
-elements (:ini:`type = min`) or the average quality over all elements (:ini:`type = avg`)
-shall be used. This is set via 
+The parameter :ini:`type` determines, which kind of mesh quality is used. It can
+be :ini:`type = min`, so that the minimum quality of all cells is considered,
+:ini:`type = avg`, so that the average quality of all mesh cells is considered,
+or :ini:`type = quantile`, which allows the user to specify a quantile and use
+the quality associated with the quantile. This is set via
 
 .. code-block:: ini
 
     type = min
 
-and defaults to :ini:`type = min`.
+and defaults to :ini:`type = min`. In order to specify the quantile for :ini:`type = quantile`, we have the following parameter
+
+.. code-block:: ini
+
+    quantile = 0.0
+
+with which the quantile is set. Note that :ini:`quantile = 0.5` computes the median of the mesh quality, i.e., half of the mesh cells
+have a lower quality while the other half has a higher quality. For a general quantile :math:`q`, the quality computed means that
+:math:`100q \%` of all cells have a lower quality, while :math:`100(1-q) \%` of all cells have a higher quality.
 
 Finally, we have the parameter :ini:`remesh_iter` in which the user can specify after how many iterations a remeshing should be performed. It is given by
 
@@ -1461,7 +1471,9 @@ in the following.
     * - :ini:`measure = skewness`
       - determines which quality measure is used
     * - :ini:`type = min`
-      - determines if minimal or average quality is considered
+      - determines if minimal, average, or quantile quality is considered
+    * - :ini:`quantile = 0.0`
+      - specifies the quantile if :ini:`type = quantile` is used.
     * - :ini:`remesh_iter`
       - When set to a value > 0, remeshing is performed every :ini:`remesh_iter` iterations.
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -153,8 +153,14 @@ def test_mesh_quality_2D():
     min_max_angle = cashocs.compute_mesh_quality(mesh, "min", "maximum_angle")
     min_radius_ratios = cashocs.compute_mesh_quality(mesh, "min", "radius_ratios")
     avg_radius_ratios = cashocs.compute_mesh_quality(mesh, "avg", "radius_ratios")
+    q_radius_ratios = cashocs.compute_mesh_quality(
+        mesh, "quantile", "radius_ratios", quantile=0.351
+    )
     min_condition = cashocs.compute_mesh_quality(mesh, "min", "condition_number")
     avg_condition = cashocs.compute_mesh_quality(mesh, "avg", "condition_number")
+    q_condition = cashocs.compute_mesh_quality(
+        mesh, "quantile", "condition_number", quantile=0.75189
+    )
 
     assert (
         abs(min_max_angle - cashocs.compute_mesh_quality(mesh, "avg", "maximum_angle"))
@@ -169,14 +175,23 @@ def test_mesh_quality_2D():
         abs(min_max_angle - cashocs.compute_mesh_quality(mesh, "min", "skewness"))
         < 1e-14
     )
+    assert (
+        abs(
+            min_max_angle
+            - cashocs.compute_mesh_quality(mesh, "quantile", "skewness", quantile=0.167)
+        )
+        < 1e-14
+    )
 
     assert abs(min_radius_ratios - avg_radius_ratios) < 1e-14
+    assert abs(min_radius_ratios - q_radius_ratios) < 1e-14
     assert (
         abs(min_radius_ratios - np.min(fenics.MeshQuality.radius_ratio_min_max(mesh)))
         < 1e-14
     )
 
     assert abs(min_condition - avg_condition) < 1e-14
+    assert abs(min_condition - q_condition) < 1e-14
     assert abs(min_condition - 0.4714045207910318) < 1e-14
 
 
@@ -204,12 +219,27 @@ def test_mesh_quality_3D():
     min_max_angle = cashocs.compute_mesh_quality(mesh, "min", "maximum_angle")
     min_radius_ratios = cashocs.compute_mesh_quality(mesh, "min", "radius_ratios")
     avg_radius_ratios = cashocs.compute_mesh_quality(mesh, "avg", "radius_ratios")
+    q_radius_ratios = cashocs.compute_mesh_quality(
+        mesh, "quantile", "radius_ratios", quantile=0.615
+    )
     min_condition = cashocs.compute_mesh_quality(mesh, "min", "condition_number")
     avg_condition = cashocs.compute_mesh_quality(mesh, "avg", "condition_number")
+    q_condition = cashocs.compute_mesh_quality(
+        mesh, "quantile", "condition_number", quantile=0.91576
+    )
     min_skewness = cashocs.compute_mesh_quality(mesh, "min", "skewness")
 
     assert (
         abs(min_max_angle - cashocs.compute_mesh_quality(mesh, "avg", "maximum_angle"))
+        < 1e-14
+    )
+    assert (
+        abs(
+            min_max_angle
+            - cashocs.compute_mesh_quality(
+                mesh, "quantile", "maximum_angle", quantile=0.715
+            )
+        )
         < 1e-14
     )
     assert abs(min_max_angle - r) < 1e-14
@@ -218,15 +248,24 @@ def test_mesh_quality_3D():
         abs(min_skewness - cashocs.compute_mesh_quality(mesh, "avg", "skewness"))
         < 1e-14
     )
+    assert (
+        abs(
+            min_skewness
+            - cashocs.compute_mesh_quality(mesh, "quantile", "skewness", quantile=0.14)
+        )
+        < 1e-14
+    )
     assert abs(min_skewness - q) < 1e-14
 
     assert abs(min_radius_ratios - avg_radius_ratios) < 1e-14
+    assert abs(min_radius_ratios - q_radius_ratios) < 1e-14
     assert (
         abs(min_radius_ratios - np.min(fenics.MeshQuality.radius_ratio_min_max(mesh)))
         < 1e-14
     )
 
     assert abs(min_condition - avg_condition) < 1e-14
+    assert abs(min_condition - q_condition) < 1e-14
     assert abs(min_condition - 0.3162277660168379) < 1e-14
 
 


### PR DESCRIPTION
This PR introduces the possibility to compute the mesh quality based on a user-specified quantile $q$. The computed quality means that $100q $ % of all mesh cells have a lower quality, whereas $100(1-q)$ % of all cells have a higher quality. Particularly, using $q=0.5$ allows to use the median mesh quality, whereas $q=0$ is equivalent to using the minimum mesh quality.

Closes #167 