### PR TITLE
cashocs.load_config now raises an exception if the config file is not found

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ of the maintenance releases, please take a look at
 2.7.0 (in development)
 ----------------------
 
-
+* The function :py:func:`cashocs.load_config` now raises an exception instead of only issuing a warning if the specified configuration file is not found.
 
 
 2.6.0 (June 26, 2025)

--- a/cashocs/io/config.py
+++ b/cashocs/io/config.py
@@ -25,7 +25,6 @@ import pathlib
 from typing import Any
 
 from cashocs import _exceptions
-from cashocs import log
 
 try:
     import cashocs_extensions  # pylint: disable=unused-import # noqa: F401
@@ -744,9 +743,11 @@ restart = False
             if file.is_file():
                 self.read(config_file)
             else:
-                log.warning(
+                raise _exceptions.InputError(
+                    "cashocs.Config",
+                    "config_file",
                     f"Could not find the specified config file {config_file}. "
-                    "Using cashocs default config instead."
+                    "Please supply a path to an existing configuration file.",
                 )
 
     def getlist(self, section: str, option: str, **kwargs: Any) -> list:


### PR DESCRIPTION
Closes #717 