### PR TITLE
Enhance the logging of cashocs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ of the maintenance releases, please take a look at
 
 * Update the logging behavior of cashocs:
 
-  * Introduce a new log level `PROFILE` which is used to log performance profiling information. This helps to de-clutter the debug and info logs.
+  * Introduce a new log level `TRACE` which is mainly used to log performance profiling information. This helps to de-clutter the debug and info logs. Trace level messages detail, e.g., the time it takes to assemble and solve linear systems.
 
   * Most (inner) solver calls, which are responsible for logging the solves of PDEs are now in the debug level. Also, all logs the solvers would have sent by default are now turned off and have to be enabled, if required, either through supplying the corresponding PETSc command line options (for the PETSc solver backend) or the configuration file (for the cashocs solver backend).
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,16 @@ of the maintenance releases, please take a look at
 
 * Revert the way :py:func:`cashocs.ts_pseudo_solve` handles convergence after the maximum number of iterations. Now, when the maximum number of (pseudo) time steps is reached, an exception is raised. This reverts the change introduced in version 2.5. This is more in line with the behavior of the SNES solver, which the pseudo time stepping relaxes. Also, this means that users are encouraged to actually reach the desired level of convergence with the pseudo time stepping solver.
 
-* Update the logging: Introduce a new log level `PROFILE` which is used to log performance profiling information. This helps to de-clutter the debug and info logs.
+* Update the logging behavior of cashocs:
+
+  * Introduce a new log level `PROFILE` which is used to log performance profiling information. This helps to de-clutter the debug and info logs.
+
+  * Most (inner) solver calls, which are responsible for logging the solves of PDEs are now in the debug level. Also, all logs the solvers would have sent by default are now turned off and have to be enabled, if required, either through supplying the corresponding PETSc command line options (for the PETSc solver backend) or the configuration file (for the cashocs solver backend).
+
+  * Timestamps for the logs are now enabled by default. If you want to change this, you can use :py:func:`cashocs.log.remove_timestamps`
+
+* For :py:func:`cashocs.ts_pseudo_solve`, there is the possibility to specify the PETSc command line option `ts_monitor`. This will activate the cashocs-implemented monitor for the pseudo time stepping and not use the default TS monitor, as one would expect. Output of the function can be toggled this way, completely analogous to :py:func:`cashocs.snes_solve`.
+
 
 
 2.6.0 (June 26, 2025)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ of the maintenance releases, please take a look at
 
 * Revert the way :py:func:`cashocs.ts_pseudo_solve` handles convergence after the maximum number of iterations. Now, when the maximum number of (pseudo) time steps is reached, an exception is raised. This reverts the change introduced in version 2.5. This is more in line with the behavior of the SNES solver, which the pseudo time stepping relaxes. Also, this means that users are encouraged to actually reach the desired level of convergence with the pseudo time stepping solver.
 
+* Update the logging: Introduce a new log level `PROFILE` which is used to log performance profiling information. This helps to de-clutter the debug and info logs.
+
 
 2.6.0 (June 26, 2025)
 ---------------------

--- a/cashocs/_constraints/solvers.py
+++ b/cashocs/_constraints/solvers.py
@@ -393,8 +393,7 @@ class AugmentedLagrangianMethod(ConstrainedSolver):
         while True:
             self.iterations += 1
 
-            log.debug(f"mu = {self.mu}")
-            log.debug(f"lambda = {self.lmbd}")
+            log.debug(f"mu = {self.mu:.3e}  lambda = {self.lmbd:.3e}")
 
             self._update_cost_functional()
 
@@ -481,7 +480,7 @@ class QuadraticPenaltyMethod(ConstrainedSolver):
         while True:
             self.iterations += 1
 
-            log.debug(f"mu = {self.mu}")
+            log.debug(f"mu = {self.mu:.3e}")
 
             self._update_cost_functional()
 

--- a/cashocs/_constraints/solvers.py
+++ b/cashocs/_constraints/solvers.py
@@ -393,7 +393,7 @@ class AugmentedLagrangianMethod(ConstrainedSolver):
         while True:
             self.iterations += 1
 
-            log.debug(f"mu = {self.mu:.3e}  lambda = {self.lmbd:.3e}")
+            log.debug(f"mu = {self.mu:.3e}  lambda = {self.lmbd}")
 
             self._update_cost_functional()
 

--- a/cashocs/_optimization/line_search/armijo_line_search.py
+++ b/cashocs/_optimization/line_search/armijo_line_search.py
@@ -141,20 +141,24 @@ class ArmijoLineSearch(line_search.LineSearch):
                     dropped_idx,
                 )
             )
-            log.debug(f"Using a stepsize of {self.stepsize:.3e}.")
 
             current_function_value = solver.objective_value
             objective_step = self._compute_objective_at_new_iterate(
                 current_function_value
             )
-            log.debug(f"Cost function value at tentative step: {objective_step:.3e}")
+            log.debug(
+                f"Stepsize: {self.stepsize:.3e}  -"
+                f"  Tentative cost function value: {objective_step:.3e}"
+            )
 
             decrease_measure = self._compute_decrease_measure(search_direction)
 
             if self._satisfies_armijo_condition(
                 objective_step, current_function_value, decrease_measure
             ):
-                log.debug("Stepsize satisfies the Armijo decrease condition.")
+                log.debug(
+                    "Accepting tentative step based on Armijo decrease condition."
+                )
                 if self.optimization_variable_abstractions.requires_remeshing():
                     log.debug(
                         "The mesh quality was sufficient for accepting the step, "
@@ -173,7 +177,9 @@ class ArmijoLineSearch(line_search.LineSearch):
                 break
 
             else:
-                log.debug("Stepsize does not satisfy the Armijo decrease condition.")
+                log.debug(
+                    "Rejecting tentative step based on Armijo decrease condition."
+                )
                 self.stepsize /= self.beta_armijo
                 self.optimization_variable_abstractions.revert_variable_update()
 

--- a/cashocs/_optimization/line_search/polynomial_line_search.py
+++ b/cashocs/_optimization/line_search/polynomial_line_search.py
@@ -153,7 +153,6 @@ class PolynomialLineSearch(line_search.LineSearch):
                     dropped_idx,
                 )
             )
-            log.debug(f"Using a stepsize of {self.stepsize:.3e}.")
             self.alpha_vals.append(self.stepsize)
 
             current_function_value = solver.objective_value
@@ -161,15 +160,19 @@ class PolynomialLineSearch(line_search.LineSearch):
             self.state_problem.has_solution = False
             objective_step = self.cost_functional.evaluate()
             self.f_vals.append(objective_step)
-
-            log.debug(f"Cost function value at tentative step: {objective_step:.3e}")
+            log.debug(
+                f"Stepsize: {self.stepsize:.3e}  -"
+                f"  Tentative cost function value: {objective_step:.3e}"
+            )
 
             decrease_measure = self._compute_decrease_measure(search_direction)
 
             if self._satisfies_armijo_condition(
                 objective_step, current_function_value, decrease_measure
             ):
-                log.debug("Stepsize satisfies the Armijo decrease condition.")
+                log.debug(
+                    "Accepting tentative step based on Armijo decrease condition."
+                )
                 if self.optimization_variable_abstractions.requires_remeshing():
                     log.debug(
                         "The mesh quality was sufficient for accepting the step, "
@@ -188,7 +191,9 @@ class PolynomialLineSearch(line_search.LineSearch):
                 break
 
             else:
-                log.debug("Stepsize does not satisfy the Armijo decrease condition.")
+                log.debug(
+                    "Rejecting tentative step based on Armijo decrease condition."
+                )
                 self.stepsize = self._compute_polynomial_stepsize(
                     current_function_value,
                     decrease_measure,

--- a/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
+++ b/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
@@ -231,11 +231,12 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
         if self.uses_custom_scalar_product and self.config.getboolean(
             "ShapeGradient", "use_p_laplacian"
         ):
-            log.warning(
+            raise _exceptions.InputError(
+                "cashocs.ShapeOptimizationProblem",
+                "shape_scalar_product",
                 "You have supplied a custom scalar product and set the parameter "
-                "``use_p_laplacian`` in the config file."
-                "cashocs will use the supplied scalar product and not the "
-                "p-Laplacian to compute the shape gradient."
+                "``use_p_laplacian`` in the config file.\n"
+                "These options are mutually exclusive. Please disable one of them.",
             )
 
         self.shape_regularization = _forms.shape_regularization.ShapeRegularization(

--- a/cashocs/_optimization/shape_optimization/shape_variable_abstractions.py
+++ b/cashocs/_optimization/shape_optimization/shape_variable_abstractions.py
@@ -25,6 +25,7 @@ import fenics
 import numpy as np
 
 from cashocs import _forms
+from cashocs import log
 from cashocs._optimization import optimization_variable_abstractions
 
 if TYPE_CHECKING:
@@ -117,6 +118,7 @@ class ShapeVariableAbstractions(
                 stepsize, 0.0, search_direction[0].vector().vec()
             )
             self.deformation.vector().apply("")
+            log.debug(f"Stepsize for mesh update: {stepsize:.3e}")
             if self.mesh_handler.move_mesh(self.deformation):
                 if (
                     self.mesh_handler.current_mesh_quality

--- a/cashocs/_pde_problems/hessian_problems.py
+++ b/cashocs/_pde_problems/hessian_problems.py
@@ -305,7 +305,7 @@ class HessianProblem:
         rsold = self.form_handler.scalar_product(self.residual, self.residual)
         eps_0 = np.sqrt(rsold)
 
-        for _ in range(self.max_it_inner_newton):
+        for i in range(self.max_it_inner_newton):
             self.reduced_hessian_application(self.p, self.q)
 
             self.box_constraints.restrictor.restrict_to_active_set(self.p, self.temp1)
@@ -327,7 +327,7 @@ class HessianProblem:
 
             rsnew = self.form_handler.scalar_product(self.residual, self.residual)
             eps = np.sqrt(rsnew)
-            log.debug(f"Residual of the CG method: {eps/eps_0:.3e} (relative)")
+            log.debug(f"{i = }  Residual of the CG method: {eps/eps_0:.3e} (relative)")
             if eps < self.inner_newton_atol + self.inner_newton_rtol * eps_0:
                 break
 
@@ -392,7 +392,7 @@ class HessianProblem:
             eps = np.sqrt(
                 self.form_handler.scalar_product(self.residual, self.residual)
             )
-            log.debug(f"Residual of the CR method: {eps/eps_0:.3e} (relative)")
+            log.debug(f"{i = }  Residual of the CR method: {eps/eps_0:.3e} (relative)")
             if (
                 eps < self.inner_newton_atol + self.inner_newton_rtol * eps_0
                 or i == self.max_it_inner_newton - 1

--- a/cashocs/_pde_problems/hessian_problems.py
+++ b/cashocs/_pde_problems/hessian_problems.py
@@ -293,7 +293,7 @@ class HessianProblem:
 
     def cg(self) -> None:
         """Solves the (truncated) Newton step with a CG method."""
-        log.begin("Solving the Newton system with a CG method.")
+        log.begin("Solving the Newton system with a CG method.", level=log.DEBUG)
         for j in range(len(self.residual)):
             self.residual[j].vector().vec().aypx(
                 0.0, -self.db.function_db.gradient[j].vector().vec()
@@ -342,7 +342,7 @@ class HessianProblem:
 
     def cr(self) -> None:
         """Solves the (truncated) Newton step with a CR method."""
-        log.begin("Solving the Newton system with a CR method.")
+        log.begin("Solving the Newton system with a CR method.", level=log.DEBUG)
         for j in range(len(self.residual)):
             self.residual[j].vector().vec().aypx(
                 0.0, -self.db.function_db.gradient[j].vector().vec()

--- a/cashocs/_pde_problems/shape_gradient_problem.py
+++ b/cashocs/_pde_problems/shape_gradient_problem.py
@@ -369,7 +369,10 @@ class _PLaplaceProjector:
 
     def solve(self) -> None:
         """Solves the p-Laplace problem for computing the shape gradient."""
-        log.begin("Computing the gradient deformation with the p-Laplace approach.")
+        log.begin(
+            "Computing the gradient deformation with the p-Laplace approach.",
+            level=log.DEBUG,
+        )
 
         self.solution.vector().vec().set(0.0)
         self.solution.vector().apply("")

--- a/cashocs/_utils/linalg.py
+++ b/cashocs/_utils/linalg.py
@@ -104,6 +104,7 @@ def split_linear_forms(forms: list[ufl.Form]) -> tuple[list[ufl.Form], list[ufl.
     return lhs_list, rhs_list
 
 
+@log.profile_to_log("assembling the linear system")
 def assemble_petsc_system(
     lhs_form: ufl.Form,
     rhs_form: ufl.Form,
@@ -135,7 +136,6 @@ def assemble_petsc_system(
         allows for well-posed problems on the boundary etc.
 
     """
-    log.begin("Assembling the forms into a linear system.", level=log.DEBUG)
     if comm is None:
         comm = mpi.COMM_WORLD
 
@@ -184,8 +184,6 @@ def assemble_petsc_system(
 
     A = A_tensor.mat()  # pylint: disable=invalid-name
     b = b_tensor.vec()
-
-    log.end()
 
     return A, b, P
 
@@ -465,6 +463,7 @@ def assemble_and_solve_linear(
 class LinearSolver:
     """A solver for linear problems arising from discretized PDEs."""
 
+    @log.profile_to_log("solving the linear system with PETSc KSP")
     def solve(
         self,
         function: fenics.Function,
@@ -499,7 +498,6 @@ class LinearSolver:
             The solution vector.
 
         """
-        log.begin("Solving a linear system with PETSc.", level=log.DEBUG)
         self.comm = function.function_space().mesh().mpi_comm()
         ksp = PETSc.KSP().create(self.comm)
         setup_matrix_and_preconditioner(ksp, A, P)
@@ -527,8 +525,6 @@ class LinearSolver:
             PETSc.garbage_cleanup(comm=self.comm)
 
         function.vector().apply("")
-
-        log.end()
 
 
 class Interpolator:

--- a/cashocs/_utils/linalg.py
+++ b/cashocs/_utils/linalg.py
@@ -104,7 +104,7 @@ def split_linear_forms(forms: list[ufl.Form]) -> tuple[list[ufl.Form], list[ufl.
     return lhs_list, rhs_list
 
 
-@log.profile_to_log("assembling the linear system")
+@log.profile_execution_time("assembling the linear system")
 def assemble_petsc_system(
     lhs_form: ufl.Form,
     rhs_form: ufl.Form,
@@ -463,7 +463,7 @@ def assemble_and_solve_linear(
 class LinearSolver:
     """A solver for linear problems arising from discretized PDEs."""
 
-    @log.profile_to_log("solving the linear system with PETSc KSP")
+    @log.profile_execution_time("solving the linear system with PETSc KSP")
     def solve(
         self,
         function: fenics.Function,

--- a/cashocs/geometry/deformations.py
+++ b/cashocs/geometry/deformations.py
@@ -25,7 +25,6 @@ import fenics
 import numpy as np
 
 from cashocs import _exceptions
-from cashocs import log
 from cashocs.geometry import measure
 
 if TYPE_CHECKING:
@@ -128,11 +127,8 @@ class DeformationHandler:
             else:
                 dof_transformation = transformation
             if not self.a_priori_tester.test(dof_transformation, float("inf")):
-                log.debug(
-                    "Mesh transformation rejected due to a priori check.\n"
-                    "Reason: Transformation would result in inverted mesh elements."
-                )
                 return False
+
         self.old_coordinates = self.mesh.coordinates().copy()
         self.coordinates += coordinate_transformation
         self.bbtree.build(self.mesh)

--- a/cashocs/geometry/mesh_handler.py
+++ b/cashocs/geometry/mesh_handler.py
@@ -281,7 +281,6 @@ class _MeshHandler:
             raise _exceptions.CashocsException("Not a valid mesh transformation")
 
         if not self.a_priori_tester.test(transformation, self.volume_change):
-            log.debug("Mesh transformation rejected due to a priori check.")
             return False
         else:
             success_flag = self.deformation_handler.move_mesh(

--- a/cashocs/geometry/mesh_testing.py
+++ b/cashocs/geometry/mesh_testing.py
@@ -80,7 +80,7 @@ class APrioriMeshTester:
             "ksp_max_it": 1000,
         }
 
-    @log.profile_to_log("testing the volume change restrictions")
+    @log.profile_execution_time("testing the volume change restrictions")
     def test(self, transformation: fenics.Function, volume_change: float) -> bool:
         r"""Check the quality of the transformation before the actual mesh is moved.
 
@@ -157,7 +157,7 @@ class IntersectionTester:
             [self.cell_counter[i] for i in range(vertex_ghost_offset)]
         )
 
-    @log.profile_to_log("testing for self-intersecting mesh cells")
+    @log.profile_execution_time("testing for self-intersecting mesh cells")
     def test(self) -> bool:
         """Checks the quality of the transformation after the actual mesh is moved.
 

--- a/cashocs/log.py
+++ b/cashocs/log.py
@@ -71,7 +71,7 @@ class Logger:
 
         self._logfiles: dict[str, logging.FileHandler] = {}
         self._indent_level = 0
-        self._use_timestamp = False
+        self._use_timestamp = True
 
         self._time_stack: list[datetime.datetime] = []
         self._group_stack: list[str] = []
@@ -277,13 +277,13 @@ class Logger:
 
         """
         if self._use_timestamp:
-            timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+            timestamp = datetime.datetime.now().isoformat()
             timestamp = timestamp + " | "
         else:
             timestamp = ""
 
         indent = 2 * self._indent_level * " "
-        return "\n".join([indent + timestamp + line for line in message.split("\n")])
+        return "\n".join([timestamp + indent + line for line in message.split("\n")])
 
     def add_logfile(
         self, filename: str, mode: str = "a", level: int = logging.DEBUG

--- a/cashocs/log.py
+++ b/cashocs/log.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import datetime
 import functools
 import logging
-from typing import Callable, ParamSpec, TYPE_CHECKING, TypeVar
+from typing import Any, Callable, TYPE_CHECKING, TypeVar
 
 import fenics
 
@@ -354,13 +354,13 @@ logging.getLogger("UFL").setLevel(logging.WARNING)
 logging.getLogger("FFC").setLevel(logging.WARNING)
 
 
-P = ParamSpec("P")
+P = TypeVar("P")
 T = TypeVar("T")
 
 
 def profile_execution_time(
     action: str, level: int = TRACE
-) -> Callable[[Callable[P, T]], Callable[P, T]]:
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """Profiles the execution time of a function.
 
     This decorator is used to determine how long it takes to complete a function call.
@@ -372,9 +372,9 @@ def profile_execution_time(
 
     """
 
-    def decorator(func: Callable[P, T]) -> Callable[P, T]:
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
         @functools.wraps(func)
-        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        def wrapper(*args: Any, **kwargs: Any) -> T:
             start_time = datetime.datetime.now()
 
             result = func(*args, **kwargs)

--- a/cashocs/log.py
+++ b/cashocs/log.py
@@ -354,7 +354,6 @@ logging.getLogger("UFL").setLevel(logging.WARNING)
 logging.getLogger("FFC").setLevel(logging.WARNING)
 
 
-P = TypeVar("P")
 T = TypeVar("T")
 
 

--- a/cashocs/nonlinear_solvers/newton_solver.py
+++ b/cashocs/nonlinear_solvers/newton_solver.py
@@ -216,7 +216,7 @@ class _NewtonSolver:
                 print(info_str + print_str, flush=True)
             self.comm.barrier()
         else:
-            log.info(info_str + print_str)
+            log.debug(info_str + print_str)
 
     @log.profile_to_log("assembling the Jacobian for Newton's method")
     def _assemble_matrix(self) -> None:
@@ -271,7 +271,9 @@ class _NewtonSolver:
             A solution of the nonlinear problem.
 
         """
-        log.begin("Solving the nonlinear PDE system with Newton's method.")
+        log.begin(
+            "Solving the nonlinear PDE system with Newton's method.", level=log.DEBUG
+        )
         self._compute_residual()
 
         self.res_0 = self.residual.norm(self.norm_type)
@@ -282,7 +284,7 @@ class _NewtonSolver:
                     print(message, flush=True)
                 self.comm.barrier()
             else:
-                log.info(message)
+                log.debug(message)
             return self.u
 
         self.res = self.res_0
@@ -345,7 +347,7 @@ class _NewtonSolver:
                     print(convergence_message, flush=True)
                 self.comm.barrier()
             else:
-                log.info(convergence_message)
+                log.debug(convergence_message)
             return True
 
         else:

--- a/cashocs/nonlinear_solvers/newton_solver.py
+++ b/cashocs/nonlinear_solvers/newton_solver.py
@@ -218,7 +218,7 @@ class _NewtonSolver:
         else:
             log.debug(info_str + print_str)
 
-    @log.profile_to_log("assembling the Jacobian for Newton's method")
+    @log.profile_execution_time("assembling the Jacobian for Newton's method")
     def _assemble_matrix(self) -> None:
         """Assembles the matrix for solving the linear problem."""
         self.assembler.assemble(self.A_fenics)
@@ -375,7 +375,7 @@ class _NewtonSolver:
                 "Maximum number of iterations were exceeded.",
             )
 
-    @log.profile_to_log("assembling the residual for Newton's method")
+    @log.profile_execution_time("assembling the residual for Newton's method")
     def _compute_residual(self) -> None:
         """Computes the residual of the nonlinear system."""
         self.residual = fenics.PETScVector(self.comm)

--- a/cashocs/nonlinear_solvers/newton_solver.py
+++ b/cashocs/nonlinear_solvers/newton_solver.py
@@ -218,9 +218,9 @@ class _NewtonSolver:
         else:
             log.info(info_str + print_str)
 
+    @log.profile_to_log("assembling the Jacobian for Newton's method")
     def _assemble_matrix(self) -> None:
         """Assembles the matrix for solving the linear problem."""
-        log.begin("Assembling the Jacobian for Newton's method.", level=log.DEBUG)
         self.assembler.assemble(self.A_fenics)
         self.A_fenics.ident_zeros()
         self.A_matrix = fenics.as_backend_type(  # pylint: disable=invalid-name
@@ -235,8 +235,6 @@ class _NewtonSolver:
             ).mat()
         else:
             self.P_matrix = None
-
-        log.end()
 
     def _compute_eta_inexact(self) -> None:
         """Computes the parameter ``eta`` for the inexact Newton method."""
@@ -375,9 +373,9 @@ class _NewtonSolver:
                 "Maximum number of iterations were exceeded.",
             )
 
+    @log.profile_to_log("assembling the residual for Newton's method")
     def _compute_residual(self) -> None:
         """Computes the residual of the nonlinear system."""
-        log.begin("Assembling the residual for Newton's method.", level=log.DEBUG)
         self.residual = fenics.PETScVector(self.comm)
         self.assembler.assemble(self.residual, self.u.vector())
         if (
@@ -389,7 +387,6 @@ class _NewtonSolver:
             self.residual[:] -= self.residual_shift[:]
 
         self.b = fenics.as_backend_type(self.residual).vec()
-        log.end()
 
     def _compute_convergence_tolerance(self) -> float:
         """Computes the tolerance for the Newton solver.

--- a/cashocs/nonlinear_solvers/picard_solver.py
+++ b/cashocs/nonlinear_solvers/picard_solver.py
@@ -165,7 +165,7 @@ def picard_iteration(
                 print(info_str + val_str, flush=True)
             comm.barrier()
         else:
-            log.info(info_str + val_str)
+            log.debug(info_str + val_str)
 
         if res <= tol:
             break

--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -43,7 +43,6 @@ default_snes_options: _typing.KspOption = {
     "snes_atol": 1e-10,
     "snes_rtol": 1e-10,
     "snes_max_it": 50,
-    "snes_monitor": None,
 }
 
 

--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -221,7 +221,7 @@ class SNESSolver:
 
     def solve(self) -> fenics.Function:
         """Solves the nonlinear problem with PETSc's SNES."""
-        log.begin("Solving the nonlinear PDE system with PETSc SNES.")
+        log.begin("Solving the nonlinear PDE system with PETSc SNES.", level=log.DEBUG)
         snes = PETSc.SNES().create()
 
         snes.setFunction(self.assemble_function, self.residual_petsc)

--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -159,7 +159,7 @@ class SNESSolver:
             )
             self.residual_shift = fenics.PETScVector(self.comm)
 
-    @log.profile_to_log("assembling the residual for SNES")
+    @log.profile_execution_time("assembling the residual for SNES")
     def assemble_function(
         self,
         snes: PETSc.SNES,  # pylint: disable=unused-argument
@@ -187,7 +187,7 @@ class SNESSolver:
             self.assembler_shift.assemble(self.residual_shift, self.u.vector())
             f[:] -= self.residual_shift[:]
 
-    @log.profile_to_log("assembling the Jacobian for SNES")
+    @log.profile_execution_time("assembling the Jacobian for SNES")
     def assemble_jacobian(
         self,
         snes: PETSc.SNES,  # pylint: disable=unused-argument

--- a/cashocs/nonlinear_solvers/ts.py
+++ b/cashocs/nonlinear_solvers/ts.py
@@ -244,6 +244,7 @@ class TSPseudoSolver:
         else:
             self.MP_petsc = None
 
+    @log.profile_to_log("assembling the residual for pseudo time stepping")
     def assemble_residual(
         self,
         ts: PETSc.TS,  # pylint: disable=unused-argument
@@ -260,7 +261,6 @@ class TSPseudoSolver:
             f (PETSc.Vec): The vector in which the residual is stored.
 
         """
-        log.begin("Assembling the residual for pseudo time stepping.", level=log.DEBUG)
         self.u.vector().vec().aypx(0.0, u)
         self.u.vector().apply("")
 
@@ -276,8 +276,8 @@ class TSPseudoSolver:
             f[:] -= self.residual_shift[:]
 
         f.scale(-1)
-        log.end()
 
+    @log.profile_to_log("assembling the Jacobian for pseudo time stepping")
     def assemble_jacobian(
         self,
         ts: PETSc.TS,  # pylint: disable=unused-argument
@@ -296,7 +296,6 @@ class TSPseudoSolver:
             P (PETSc.Mat): The matrix for storing the preconditioner.
 
         """
-        log.begin("Assembling the Jacobian for pseudo time stepping.", level=log.DEBUG)
         self.u.vector().vec().aypx(0.0, u)
         self.u.vector().apply("")
 
@@ -316,8 +315,6 @@ class TSPseudoSolver:
             P_petsc = fenics.as_backend_type(P).mat()  # pylint: disable=invalid-name,
             P_petsc.scale(-1)
             P_petsc.assemble()
-
-        log.end()
 
     def assemble_i_function(
         self,
@@ -416,7 +413,7 @@ class TSPseudoSolver:
         else:
             relative_residual = self.res_current / self.res_initial
 
-        log.debug(
+        log.info(
             f"TS {i = }  {t = :.3e}  "
             f"residual: {relative_residual:.3e} (rel)  "
             f"{self.res_current:.3e} (abs)"

--- a/cashocs/nonlinear_solvers/ts.py
+++ b/cashocs/nonlinear_solvers/ts.py
@@ -440,7 +440,7 @@ class TSPseudoSolver:
             The solution obtained by the solver.
 
         """
-        log.begin("Solving the PDE system with pseudo time stepping.")
+        log.begin("Solving the PDE system with pseudo time stepping.", level=log.DEBUG)
         ts = PETSc.TS().create()
         ts.setProblemType(ts.ProblemType.NONLINEAR)
 

--- a/cashocs/nonlinear_solvers/ts.py
+++ b/cashocs/nonlinear_solvers/ts.py
@@ -246,7 +246,7 @@ class TSPseudoSolver:
         else:
             self.MP_petsc = None
 
-    @log.profile_to_log("assembling the residual for pseudo time stepping")
+    @log.profile_execution_time("assembling the residual for pseudo time stepping")
     def assemble_residual(
         self,
         ts: PETSc.TS,  # pylint: disable=unused-argument
@@ -279,7 +279,7 @@ class TSPseudoSolver:
 
         f.scale(-1)
 
-    @log.profile_to_log("assembling the Jacobian for pseudo time stepping")
+    @log.profile_execution_time("assembling the Jacobian for pseudo time stepping")
     def assemble_jacobian(
         self,
         ts: PETSc.TS,  # pylint: disable=unused-argument

--- a/cashocs/space_mapping/optimal_control.py
+++ b/cashocs/space_mapping/optimal_control.py
@@ -58,7 +58,7 @@ class FineModel(abc.ABC):
     controls: list[fenics.Function]
     cost_functional_value: float
 
-    @log.profile_to_log("simulating the fine model")
+    @log.profile_execution_time("simulating the fine model")
     def simulate(self) -> None:
         """Simulates the fine model.
 

--- a/cashocs/space_mapping/optimal_control.py
+++ b/cashocs/space_mapping/optimal_control.py
@@ -58,6 +58,14 @@ class FineModel(abc.ABC):
     controls: list[fenics.Function]
     cost_functional_value: float
 
+    @log.profile_to_log("simulating the fine model")
+    def simulate(self) -> None:
+        """Simulates the fine model.
+
+        This is done in this method so it can be decorated for logging purposes.
+        """
+        self.solve_and_evaluate()
+
     @abc.abstractmethod
     def solve_and_evaluate(self) -> None:
         """Solves and evaluates the fine model.
@@ -559,9 +567,7 @@ class SpaceMappingProblem:
         log.begin("Solving the space mapping problem.")
         self._compute_intial_guess()
 
-        log.begin("Simulating the fine model.")
-        self.fine_model.solve_and_evaluate()
-        log.end()
+        self.fine_model.simulate()
 
         self.parameter_extraction._solve(  # pylint: disable=protected-access
             self.iteration
@@ -693,9 +699,7 @@ class SpaceMappingProblem:
                 )
                 self.x[i].vector().apply("")
 
-            log.begin("Simulating the fine model.")
-            self.fine_model.solve_and_evaluate()
-            log.end()
+            self.fine_model.simulate()
 
             self.parameter_extraction._solve(  # pylint: disable=protected-access
                 self.iteration,
@@ -721,9 +725,7 @@ class SpaceMappingProblem:
                     )
                     self.x[i].vector().apply("")
 
-                log.begin("Simulating the fine model.")
-                self.fine_model.solve_and_evaluate()
-                log.end()
+                self.fine_model.simulate()
 
                 self.parameter_extraction._solve(  # pylint: disable=protected-access
                     self.iteration,

--- a/cashocs/space_mapping/shape_optimization.py
+++ b/cashocs/space_mapping/shape_optimization.py
@@ -69,7 +69,7 @@ class FineModel(abc.ABC):
         """
         self.mesh = fenics.Mesh(mesh)
 
-    @log.profile_to_log("simulating the fine model")
+    @log.profile_execution_time("simulating the fine model")
     def simulate(self) -> None:
         """Simulates the fine model.
 

--- a/cashocs/space_mapping/shape_optimization.py
+++ b/cashocs/space_mapping/shape_optimization.py
@@ -69,6 +69,14 @@ class FineModel(abc.ABC):
         """
         self.mesh = fenics.Mesh(mesh)
 
+    @log.profile_to_log("simulating the fine model")
+    def simulate(self) -> None:
+        """Simulates the fine model.
+
+        This is done in this method so it can be decorated for logging purposes.
+        """
+        self.solve_and_evaluate()
+
     @abc.abstractmethod
     def solve_and_evaluate(self) -> None:
         """Solves and evaluates the fine model.
@@ -588,9 +596,7 @@ class SpaceMappingProblem:
         log.begin("Solving the space mapping problem.")
         self._compute_initial_guess()
 
-        log.begin("Simulating the fine model.")
-        self.fine_model.solve_and_evaluate()
-        log.end()
+        self.fine_model.simulate()
 
         self.parameter_extraction._solve(  # pylint: disable=protected-access
             self.iteration
@@ -719,9 +725,7 @@ class SpaceMappingProblem:
                     "possible due to intersections"
                 )
 
-            log.begin("Simulating the fine model.")
-            self.fine_model.solve_and_evaluate()
-            log.end()
+            self.fine_model.simulate()
 
             self.parameter_extraction._solve(  # pylint: disable=protected-access
                 self.iteration
@@ -753,9 +757,7 @@ class SpaceMappingProblem:
                 self.transformation.vector().apply("")
                 success = self.deformation_handler_fine.move_mesh(self.transformation)
                 if success:
-                    log.begin("Simulating the fine model.")
-                    self.fine_model.solve_and_evaluate()
-                    log.end()
+                    self.fine_model.simulate()
 
                     # pylint: disable=protected-access
                     self.parameter_extraction._solve(self.iteration)

--- a/tests/test_p_laplacian.py
+++ b/tests/test_p_laplacian.py
@@ -98,7 +98,7 @@ def test_2_laplacian(config_sop, geometry, e, bcs, J, u, p, initial_coordinates)
     )
     sop1.solve(algorithm="gd", rtol=1e-2, max_iter=22)
 
-    config_sop.set("ShapeGradient", "use_p_laplacian", "True")
+    config_sop.set("ShapeGradient", "use_p_laplacian", "False")
     geometry.mesh.coordinates()[:, :] = initial_coordinates
     geometry.mesh.bounding_box_tree().build(geometry.mesh)
     sop2 = cashocs.ShapeOptimizationProblem(


### PR DESCRIPTION
This PR introduces a new log level "trace" which is, at the moment, mainly used for de-clustering the debug and info logs. In all, logs should be easier to read now.

Also, some logs that were on the info level have been put into debug and stuff from debug into trace, so that the logs are less cluttered.

Time stamps are now activated by default, but these can be toggled off.