### PR TITLE
Fix a bug where the TS solver does not use the supplied preconditioner forms

### DIFF
--- a/cashocs/nonlinear_solvers/ts.py
+++ b/cashocs/nonlinear_solvers/ts.py
@@ -313,7 +313,7 @@ class TSPseudoSolver:
 
         if self.preconditioner_form is not None:
             P = fenics.PETScMatrix(P)  # pylint: disable=invalid-name
-            self.assembler.assemble(P)
+            self.assembler_pc.assemble(P)
             P.ident_zeros()
 
             P_petsc = fenics.as_backend_type(P).mat()  # pylint: disable=invalid-name,


### PR DESCRIPTION
Previously, TS used the same form as for the Jacobian. Now, the form supplied by the user is used as intended.