### PR TITLE
Upgrade to macos-15 in the CI

### DIFF
--- a/.github/workflows/conda_test.yml
+++ b/.github/workflows/conda_test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Test conda installation
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-15]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -15,8 +15,8 @@ env:
 
 jobs:
   serial_tests:
-    name: Test (py=${{ matrix.python-version}}, macos-13)
-    runs-on: macos-13
+    name: Test (py=${{ matrix.python-version}}, macos-15)
+    runs-on: macos-15
     defaults:
       run:
         shell: bash -el {0}


### PR DESCRIPTION
This PR upgrades the macos pipelines to use macos-15. This is due to macos-13 being deprecated, see https://github.com/actions/runner-images/issues/13046