### PR TITLE
Fix the CI with the new docker image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         conda run --no-capture-output -n env pip install .[all]
 
     - name: Show conda info
-      run: conda info -n env
+      run: conda info
 
     - name: Show list of all installed packages
       run: conda list -n env


### PR DESCRIPTION
Apparently, docker run has to be used inside github actions, as this overrides the entrypoint of the image.