### PR TITLE
Print arguments on separate lines in the docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,6 +82,7 @@ autodoc_mock_imports = [
 ]
 autodoc_typehints = "both"
 autoclass_content = "both"
+maximum_signature_line_length = 3
 
 highlight_language = "python"
 


### PR DESCRIPTION
This change enables sphinx to mainly print each argument of a function / method in a separate line, increasing readability.