### PR TITLE
Better toc with pydata-sphinx-theme 0.17

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,6 +85,7 @@ autoclass_content = "both"
 maximum_signature_line_length = 3
 
 highlight_language = "python"
+toc_object_entries_show_parents = "hide"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
With the new version of the sphinx theme, a toc is built for the api documentation. However, with the default values it is quite clunky - this PR fixes this and improves the readability significantly.