### PR TITLE
Support PETSc 3.25

### DIFF
--- a/cashocs/_utils/linalg.py
+++ b/cashocs/_utils/linalg.py
@@ -286,7 +286,11 @@ def setup_fieldsplit_preconditioner(
                 dm.setUp()
 
                 ksp.setDM(dm)
-                ksp.setDMActive(False)
+                petsc_version = PETSc.Sys.getVersion()
+                if petsc_version[0] == 3 and petsc_version[1] >= 25:
+                    ksp.setDMActive(ksp.DMActive.ALL, False)
+                else:
+                    ksp.setDMActive(False)
 
 
 def define_ksp_options(


### PR DESCRIPTION
With fenics getting support for PETSc 3.25 (on conda-forge), this PR ensures that cashocs also supports this version.
The only thing needed to change: ksp.setDMActive now takes two arguments, where a KSP.DMActive object must be used in addition to the boolean.