### PR TITLE
Update github actions workflows

### DIFF
--- a/.github/workflows/conda_test.yml
+++ b/.github/workflows/conda_test.yml
@@ -30,7 +30,7 @@ jobs:
           miniforge-version: latest
           python-version: 3.14
           activate-environment: test
-          auto-activate-base: false
+          auto-activate: false
           auto-update-conda: true
           conda-remove-defaults: true
       

--- a/.github/workflows/test_demos.yml
+++ b/.github/workflows/test_demos.yml
@@ -33,7 +33,7 @@ jobs:
         miniforge-version: latest
         python-version: 3.14
         activate-environment: test
-        auto-activate-base: false
+        auto-activate: false
         conda-remove-defaults: true
 
     - name: Show conda info
@@ -72,7 +72,7 @@ jobs:
         miniforge-version: latest
         python-version: 3.14
         activate-environment: test
-        auto-activate-base: false
+        auto-activate: false
         conda-remove-defaults: true
 
     - name: Show conda info

--- a/.github/workflows/tests_macos.yml
+++ b/.github/workflows/tests_macos.yml
@@ -33,7 +33,7 @@ jobs:
         miniforge-version: latest
         python-version: ${{ matrix.python-version }}
         activate-environment: test
-        auto-activate-base: false
+        auto-activate: false
         conda-remove-defaults: true
 
     - name: Show conda info

--- a/.github/workflows/tests_parallel.yml
+++ b/.github/workflows/tests_parallel.yml
@@ -37,7 +37,7 @@ jobs:
         miniforge-version: latest
         python-version: ${{ matrix.python-version }}
         activate-environment: test
-        auto-activate-base: false
+        auto-activate: false
         conda-remove-defaults: true
 
     - name: Show conda info

--- a/.github/workflows/tests_serial.yml
+++ b/.github/workflows/tests_serial.yml
@@ -34,7 +34,7 @@ jobs:
         miniforge-version: latest
         python-version: ${{ matrix.python-version }}
         activate-environment: test
-        auto-activate-base: false
+        auto-activate: false
         conda-remove-defaults: true
 
     - name: Show conda info


### PR DESCRIPTION
Remove deprecated call to auto-activate-base.
This is replaced by auto-activate.