### PR TITLE
Improve PETSc memory management

### DIFF
--- a/cashocs/_utils/linalg.py
+++ b/cashocs/_utils/linalg.py
@@ -532,12 +532,13 @@ class LinearSolver:
 
         ksp.setTolerances(rtol=rtol, atol=atol)
 
-        ksp.solve(b, x)
-        converged_reason = ksp.getConvergedReason()
-
-        if hasattr(PETSc, "garbage_cleanup"):
+        try:
+            ksp.solve(b, x)
+            converged_reason = ksp.getConvergedReason()
+        finally:
             ksp.destroy()
-            PETSc.garbage_cleanup(comm=self.comm)
+            if hasattr(PETSc, "garbage_cleanup"):
+                PETSc.garbage_cleanup(comm=self.comm)
 
         if converged_reason < 0:
             raise _exceptions.PETScKSPError(converged_reason)
@@ -545,9 +546,61 @@ class LinearSolver:
         function.vector().apply("")
 
 
+class EquationResidualComputer:
+    """Computes equation-wise residual norms for a fixed function space."""
+
+    def __init__(self, function_space: fenics.FunctionSpace) -> None:
+        """Initializes the residual computer.
+
+        Args:
+            function_space: The function space defining the equations.
+
+        """
+        self.function_space = function_space
+        if isinstance(
+            function_space.ufl_element(), ufl.VectorElement | ufl.FiniteElement
+        ):
+            self.is_sets = []
+        else:
+            self.is_sets = [
+                PETSc.IS().createGeneral(function_space.sub(i).dofmap().dofs())
+                for i in range(function_space.num_sub_spaces())
+            ]
+
+    def compute(self, residual: PETSc.Vec) -> np.ndarray:
+        """Computes equation-wise residual norms.
+
+        Args:
+            residual: The PETSc vector containing the (nonlinear) residual.
+
+        Returns:
+            A list of residual norms for the individual equations.
+
+        """
+        equation_residual_vectors = []
+        try:
+            for iset in self.is_sets:
+                equation_residual_vectors.append(residual.getSubVector(iset))
+
+            return np.array(
+                [r.norm(PETSc.NormType.NORM_2) for r in equation_residual_vectors]
+            )
+        finally:
+            for iset, vector in zip(
+                self.is_sets, equation_residual_vectors, strict=False
+            ):
+                residual.restoreSubVector(iset, vector)
+
+    def destroy(self) -> None:
+        """Destroys the cached PETSc index sets."""
+        for iset in self.is_sets:
+            iset.destroy()
+        self.is_sets = []
+
+
 def compute_equation_residuals(
     residual: PETSc.Vec, function_space: fenics.FunctionSpace
-) -> list[float]:
+) -> np.ndarray:
     """Splits the residual to the individual equations and computes the norm.
 
     Args:
@@ -558,32 +611,11 @@ def compute_equation_residuals(
         A list of residual norms for the individual equations.
 
     """
-    if not isinstance(
-        function_space.ufl_element(), ufl.VectorElement | ufl.FiniteElement
-    ):
-        num_equations = function_space.num_sub_spaces()
-        is_sets = [
-            PETSc.IS().createGeneral(function_space.sub(i).dofmap().dofs())
-            for i in range(num_equations)
-        ]
-
-        equation_residual_vectors = []
-        try:
-            for iset in is_sets:
-                equation_residual_vectors.append(residual.getSubVector(iset))
-
-            equation_residual_norms = [
-                r.norm(PETSc.NormType.NORM_2) for r in equation_residual_vectors
-            ]
-        finally:
-            for iset, vector in zip(is_sets, equation_residual_vectors, strict=True):
-                residual.restoreSubVector(iset, vector)
-
-            for iset in is_sets:
-                iset.destroy()
-
-    else:
-        equation_residual_norms = []
+    residual_computer = EquationResidualComputer(function_space)
+    try:
+        equation_residual_norms = residual_computer.compute(residual)
+    finally:
+        residual_computer.destroy()
 
     return equation_residual_norms
 

--- a/cashocs/_utils/linalg.py
+++ b/cashocs/_utils/linalg.py
@@ -217,6 +217,24 @@ def setup_petsc_options(
         objs[i].setFromOptions()
 
 
+def _set_fieldsplit_index_sets(
+    pc: PETSc.PC, function_space: fenics.FunctionSpace
+) -> None:
+    idx = []
+    name = []
+    for i in range(function_space.num_sub_spaces()):
+        idx_i = PETSc.IS().createGeneral(function_space.sub(i).dofmap().dofs())
+        idx.append(idx_i)
+        name.append(f"{i:d}")
+
+    idx_tuples = list(zip(name, idx, strict=True))
+    try:
+        pc.setFieldSplitIS(*idx_tuples)
+    finally:
+        for idx_i in idx:
+            idx_i.destroy()
+
+
 def setup_fieldsplit_preconditioner(
     fun: fenics.Function | None,
     ksp: PETSc.KSP,
@@ -247,17 +265,7 @@ def setup_fieldsplit_preconditioner(
             if not any(key.endswith("_fields") for key in options.keys()):
                 pc = ksp.getPC()
                 pc.setType(PETSc.PC.Type.FIELDSPLIT)
-                idx = []
-                name = []
-                for i in range(function_space.num_sub_spaces()):
-                    idx_i = PETSc.IS().createGeneral(
-                        function_space.sub(i).dofmap().dofs()
-                    )
-                    idx.append(idx_i)
-                    name.append(f"{i:d}")
-                idx_tuples = zip(name, idx, strict=True)
-
-                pc.setFieldSplitIS(*idx_tuples)
+                _set_fieldsplit_index_sets(pc, function_space)
             else:
                 dof_total = function_space.dofmap().dofs()
                 offset = np.min(dof_total)
@@ -291,6 +299,8 @@ def setup_fieldsplit_preconditioner(
                     ksp.setDMActive(ksp.DMActive.ALL, False)
                 else:
                     ksp.setDMActive(False)
+                dm.destroy()
+                section.destroy()
 
 
 def define_ksp_options(
@@ -557,10 +567,20 @@ def compute_equation_residuals(
             for i in range(num_equations)
         ]
 
-        equation_residual_vectors = [residual.getSubVector(iset) for iset in is_sets]
-        equation_residual_norms = [
-            r.norm(PETSc.NormType.NORM_2) for r in equation_residual_vectors
-        ]
+        equation_residual_vectors = []
+        try:
+            for iset in is_sets:
+                equation_residual_vectors.append(residual.getSubVector(iset))
+
+            equation_residual_norms = [
+                r.norm(PETSc.NormType.NORM_2) for r in equation_residual_vectors
+            ]
+        finally:
+            for iset, vector in zip(is_sets, equation_residual_vectors, strict=True):
+                residual.restoreSubVector(iset, vector)
+
+            for iset in is_sets:
+                iset.destroy()
 
     else:
         equation_residual_norms = []

--- a/cashocs/log.py
+++ b/cashocs/log.py
@@ -107,31 +107,6 @@ class Logger:
             self._log.log(level, self._format(message))
         self.comm.barrier()
 
-    def is_enabled_for(self, level: int) -> bool:
-        """Checks whether any handler would emit a message at ``level``.
-
-        Args:
-            level: The log level that should be checked.
-
-        Returns:
-            Whether a message with this level can be emitted by the logger.
-
-        """
-        if not self._log.isEnabledFor(level):
-            return False
-
-        logger: logging.Logger | None = self._log
-        while logger is not None:
-            for handler in logger.handlers:
-                if level >= handler.level:
-                    return True
-
-            if not logger.propagate:
-                break
-            logger = logger.parent
-
-        return False
-
     def trace(self, message: str) -> None:
         """Issues a message at the trace level.
 
@@ -374,7 +349,6 @@ add_timestamps = cashocs_logger.add_timestamps
 remove_timestamps = cashocs_logger.remove_timestamps
 add_handler = cashocs_logger.add_handler
 set_comm = cashocs_logger.set_comm
-is_enabled_for = cashocs_logger.is_enabled_for
 
 fenics.set_log_level(fenics.LogLevel.WARNING)
 logging.getLogger("UFL").setLevel(logging.WARNING)

--- a/cashocs/log.py
+++ b/cashocs/log.py
@@ -107,6 +107,31 @@ class Logger:
             self._log.log(level, self._format(message))
         self.comm.barrier()
 
+    def is_enabled_for(self, level: int) -> bool:
+        """Checks whether any handler would emit a message at ``level``.
+
+        Args:
+            level: The log level that should be checked.
+
+        Returns:
+            Whether a message with this level can be emitted by the logger.
+
+        """
+        if not self._log.isEnabledFor(level):
+            return False
+
+        logger: logging.Logger | None = self._log
+        while logger is not None:
+            for handler in logger.handlers:
+                if level >= handler.level:
+                    return True
+
+            if not logger.propagate:
+                break
+            logger = logger.parent
+
+        return False
+
     def trace(self, message: str) -> None:
         """Issues a message at the trace level.
 
@@ -349,6 +374,7 @@ add_timestamps = cashocs_logger.add_timestamps
 remove_timestamps = cashocs_logger.remove_timestamps
 add_handler = cashocs_logger.add_handler
 set_comm = cashocs_logger.set_comm
+is_enabled_for = cashocs_logger.is_enabled_for
 
 fenics.set_log_level(fenics.LogLevel.WARNING)
 logging.getLogger("UFL").setLevel(logging.WARNING)

--- a/cashocs/nonlinear_solvers/newton_solver.py
+++ b/cashocs/nonlinear_solvers/newton_solver.py
@@ -171,10 +171,16 @@ class _NewtonSolver:
 
         self.comm = self.u.function_space().mesh().mpi_comm()
         # pylint: disable=invalid-name
-        self.A_fenics = self.A_tensor or fenics.PETScMatrix(self.comm)
-        self.residual = self.b_tensor or fenics.PETScVector(self.comm)
-        self.b = fenics.as_backend_type(self.residual).vec()
-        self.A_matrix = fenics.as_backend_type(self.A_fenics).mat()
+        if self.A_tensor is not None:
+            self.A_fenics = self.A_tensor
+        else:
+            self.A_fenics = fenics.PETScMatrix(self.comm)
+        if self.b_tensor is not None:
+            self.residual = self.b_tensor
+        else:
+            self.residual = fenics.PETScVector(self.comm)
+        self.b = self.residual.vec()
+        self.A_matrix = self.A_fenics.mat()
 
         self.P_fenics = fenics.PETScMatrix(self.comm)
 
@@ -195,6 +201,9 @@ class _NewtonSolver:
         self.res = 1.0
         self.res_0 = 1.0
         self.tol = 1.0
+        self.residual_computer = _utils.linalg.EquationResidualComputer(
+            self.function_space
+        )
 
     def _print_output(self) -> None:
         """Prints the output of the current iteration to the console."""
@@ -217,40 +226,31 @@ class _NewtonSolver:
         else:
             log.debug(info_str + print_str)
 
-        if log.is_enabled_for(log.DEBUG):
-            self.equation_residuals_current = np.array(
-                _utils.compute_equation_residuals(
-                    self.residual.vec(), self.function_space
-                )
-            )
-            for j, res in enumerate(self.equation_residuals_current):
-                res_init = self.equation_residuals_initial[j]
-                if res_init == 0:
-                    res_rel = res
-                else:
-                    res_rel = res / res_init
+        self.equation_residuals_current = self.residual_computer.compute(
+            self.residual.vec()
+        )
+        for j, res in enumerate(self.equation_residuals_current):
+            res_init = self.equation_residuals_initial[j]
+            if res_init == 0:
+                res_rel = res
+            else:
+                res_rel = res / res_init
 
-                log.debug(
-                    f"Equation {j:d} "
-                    f"relative resid {res_rel:.3e} "
-                    f"absolute resid {res:.3e}"
-                )
+            log.debug(
+                f"Equation {j:d} relative resid {res_rel:.3e} absolute resid {res:.3e}"
+            )
 
     @log.profile_execution_time("assembling the Jacobian for Newton's method")
     def _assemble_matrix(self) -> None:
         """Assembles the matrix for solving the linear problem."""
         self.assembler.assemble(self.A_fenics)
         self.A_fenics.ident_zeros()
-        self.A_matrix = fenics.as_backend_type(  # pylint: disable=invalid-name
-            self.A_fenics
-        ).mat()
+        self.A_matrix = self.A_fenics.mat()
 
         if self.preconditioner_form is not None:
             self.assembler_pc.assemble(self.P_fenics)
             self.P_fenics.ident_zeros()
-            self.P_matrix = fenics.as_backend_type(  # pylint: disable=invalid-name
-                self.P_fenics
-            ).mat()
+            self.P_matrix = self.P_fenics.mat()  # pylint: disable=invalid-name
         else:
             self.P_matrix = None
 
@@ -295,14 +295,9 @@ class _NewtonSolver:
         self._compute_residual()
 
         self.res_0 = self.residual.norm(self.norm_type)
-        if log.is_enabled_for(log.DEBUG):
-            self.equation_residuals_initial = np.array(
-                _utils.compute_equation_residuals(
-                    self.residual.vec(), self.function_space
-                )
-            )
-        else:
-            self.equation_residuals_initial = np.array([])
+        self.equation_residuals_initial = self.residual_computer.compute(
+            self.residual.vec()
+        )
         if self.res_0 == 0.0:  # pragma: no cover
             message = "Residual vanishes, input is already a solution."
             if self.verbose:
@@ -311,6 +306,7 @@ class _NewtonSolver:
                 self.comm.barrier()
             else:
                 log.debug(message)
+            self.residual_computer.destroy()
             return self.u
 
         self.res = self.res_0
@@ -358,6 +354,7 @@ class _NewtonSolver:
                 break
 
         log.end()
+        self.residual_computer.destroy()
         self._check_if_successful()
 
         return self.u
@@ -404,7 +401,6 @@ class _NewtonSolver:
     @log.profile_execution_time("assembling the residual for Newton's method")
     def _compute_residual(self) -> None:
         """Computes the residual of the nonlinear system."""
-        self.residual = fenics.PETScVector(self.comm)
         self.assembler.assemble(self.residual, self.u.vector())
         if (
             self.shift is not None
@@ -414,7 +410,7 @@ class _NewtonSolver:
             self.assembler_shift.assemble(self.residual_shift, self.u.vector())
             self.residual[:] -= self.residual_shift[:]
 
-        self.b = fenics.as_backend_type(self.residual).vec()
+        self.b = self.residual.vec()
 
     def _compute_convergence_tolerance(self) -> float:
         """Computes the tolerance for the Newton solver.

--- a/cashocs/nonlinear_solvers/newton_solver.py
+++ b/cashocs/nonlinear_solvers/newton_solver.py
@@ -217,19 +217,24 @@ class _NewtonSolver:
         else:
             log.debug(info_str + print_str)
 
-        self.equation_residuals_current = np.array(
-            _utils.compute_equation_residuals(self.residual.vec(), self.function_space)
-        )
-        for j, res in enumerate(self.equation_residuals_current):
-            res_init = self.equation_residuals_initial[j]
-            if res_init == 0:
-                res_rel = res
-            else:
-                res_rel = res / res_init
-
-            log.debug(
-                f"Equation {j:d} relative resid {res_rel:.3e} absolute resid {res:.3e}"
+        if log.is_enabled_for(log.DEBUG):
+            self.equation_residuals_current = np.array(
+                _utils.compute_equation_residuals(
+                    self.residual.vec(), self.function_space
+                )
             )
+            for j, res in enumerate(self.equation_residuals_current):
+                res_init = self.equation_residuals_initial[j]
+                if res_init == 0:
+                    res_rel = res
+                else:
+                    res_rel = res / res_init
+
+                log.debug(
+                    f"Equation {j:d} "
+                    f"relative resid {res_rel:.3e} "
+                    f"absolute resid {res:.3e}"
+                )
 
     @log.profile_execution_time("assembling the Jacobian for Newton's method")
     def _assemble_matrix(self) -> None:
@@ -290,9 +295,14 @@ class _NewtonSolver:
         self._compute_residual()
 
         self.res_0 = self.residual.norm(self.norm_type)
-        self.equation_residuals_initial = np.array(
-            _utils.compute_equation_residuals(self.residual.vec(), self.function_space)
-        )
+        if log.is_enabled_for(log.DEBUG):
+            self.equation_residuals_initial = np.array(
+                _utils.compute_equation_residuals(
+                    self.residual.vec(), self.function_space
+                )
+            )
+        else:
+            self.equation_residuals_initial = np.array([])
         if self.res_0 == 0.0:  # pragma: no cover
             message = "Residual vanishes, input is already a solution."
             if self.verbose:

--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -192,7 +192,7 @@ class SNESSolver:
             self.assembler_shift.assemble(self.residual_shift, self.u.vector())
             f[:] -= self.residual_shift[:]
 
-        self.residual_convergence = f
+        self.residual_convergence = f.vec()
 
     @log.profile_execution_time("assembling the Jacobian for SNES")
     def assemble_jacobian(

--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -238,7 +238,7 @@ class SNESSolver:
             norm: The current residual norm.
 
         """
-        if self.residual_convergence:
+        if self.residual_convergence and log.is_enabled_for(log.DEBUG):
             self.equation_residuals_current = np.array(
                 _utils.compute_equation_residuals(
                     self.residual_convergence, self.u.function_space()
@@ -276,11 +276,14 @@ class SNESSolver:
             )
             self.is_preassembled = True
 
-        self.equation_residuals_initial = np.array(
-            _utils.compute_equation_residuals(
-                self.residual_convergence, self.u.function_space()
+        if log.is_enabled_for(log.DEBUG):
+            self.equation_residuals_initial = np.array(
+                _utils.compute_equation_residuals(
+                    self.residual_convergence, self.u.function_space()
+                )
             )
-        )
+        else:
+            self.equation_residuals_initial = np.array([])
 
         _utils.setup_petsc_options([snes], [self.petsc_options])
         snes.setTolerances(rtol=self.rtol, atol=self.atol, max_it=self.max_iter)

--- a/cashocs/nonlinear_solvers/snes.py
+++ b/cashocs/nonlinear_solvers/snes.py
@@ -23,7 +23,6 @@ import copy
 from typing import TYPE_CHECKING
 
 import fenics
-import numpy as np
 from petsc4py import PETSc
 
 try:
@@ -161,6 +160,9 @@ class SNESSolver:
             self.residual_shift = fenics.PETScVector(self.comm)
 
         self.residual_convergence: PETSc.Vec | None = None
+        self.residual_computer = _utils.linalg.EquationResidualComputer(
+            self.u.function_space()
+        )
 
     @log.profile_execution_time("assembling the residual for SNES")
     def assemble_function(
@@ -190,7 +192,7 @@ class SNESSolver:
             self.assembler_shift.assemble(self.residual_shift, self.u.vector())
             f[:] -= self.residual_shift[:]
 
-        self.residual_convergence = f.vec().copy()
+        self.residual_convergence = f
 
     @log.profile_execution_time("assembling the Jacobian for SNES")
     def assemble_jacobian(
@@ -238,11 +240,9 @@ class SNESSolver:
             norm: The current residual norm.
 
         """
-        if self.residual_convergence and log.is_enabled_for(log.DEBUG):
-            self.equation_residuals_current = np.array(
-                _utils.compute_equation_residuals(
-                    self.residual_convergence, self.u.function_space()
-                )
+        if self.residual_convergence:
+            self.equation_residuals_current = self.residual_computer.compute(
+                self.residual_convergence
             )
 
             for j, res in enumerate(self.equation_residuals_current):
@@ -276,14 +276,9 @@ class SNESSolver:
             )
             self.is_preassembled = True
 
-        if log.is_enabled_for(log.DEBUG):
-            self.equation_residuals_initial = np.array(
-                _utils.compute_equation_residuals(
-                    self.residual_convergence, self.u.function_space()
-                )
-            )
-        else:
-            self.equation_residuals_initial = np.array([])
+        self.equation_residuals_initial = self.residual_computer.compute(
+            self.residual_convergence
+        )
 
         _utils.setup_petsc_options([snes], [self.petsc_options])
         snes.setTolerances(rtol=self.rtol, atol=self.atol, max_it=self.max_iter)
@@ -294,12 +289,15 @@ class SNESSolver:
         x.vector().vec().aypx(0.0, self.u.vector().vec())
         x.vector().apply("")
 
-        snes.solve(None, x.vector().vec())
-        converged_reason = snes.getConvergedReason()
+        try:
+            snes.solve(None, x.vector().vec())
+            converged_reason = snes.getConvergedReason()
 
-        if hasattr(PETSc, "garbage_cleanup"):
+        finally:
             snes.destroy()
-            PETSc.garbage_cleanup(comm=self.comm)
+            self.residual_computer.destroy()
+            if hasattr(PETSc, "garbage_cleanup"):
+                PETSc.garbage_cleanup(comm=self.comm)
 
         self.u.vector().vec().setArray(x.vector().vec())
         self.u.vector().apply("")

--- a/cashocs/nonlinear_solvers/ts.py
+++ b/cashocs/nonlinear_solvers/ts.py
@@ -127,6 +127,7 @@ class TSPseudoSolver:
         self.dtol = 1e4
         self.max_iter = max_iter
         self.res_current = -1.0
+        self.residual_computer = _utils.linalg.EquationResidualComputer(self.space)
 
         if petsc_options is None:
             self.petsc_options: _typing.KspOption = copy.deepcopy(
@@ -295,8 +296,8 @@ class TSPseudoSolver:
         ts: PETSc.TS,  # pylint: disable=unused-argument
         t: float,  # pylint: disable=unused-argument
         u: PETSc.Vec,
-        J: PETSc.Mat,  # pylint: disable=invalid-name,
-        P: PETSc.Mat,  # pylint: disable=invalid-name,
+        J: PETSc.Mat,  # pylint: disable=invalid-name,unused-argument
+        P: PETSc.Mat,  # pylint: disable=invalid-name,unused-argument
     ) -> None:
         """Interface for PETSc TSSetRHSJacobian.
 
@@ -412,12 +413,6 @@ class TSPseudoSolver:
 
         """
         self.res_current = self.compute_nonlinear_residual(u)
-        if log.is_enabled_for(log.DEBUG):
-            self.equation_residuals_current = np.array(
-                _utils.compute_equation_residuals(
-                    self.residual_convergence.vec(), self.space
-                )
-            )
 
         if self.res_initial == 0:
             relative_residual = self.res_current
@@ -434,19 +429,20 @@ class TSPseudoSolver:
         if self.comm.rank == 0 and self.has_monitor_output:
             print(monitor_str, flush=True)
 
-        if log.is_enabled_for(log.DEBUG):
-            for j, res in enumerate(self.equation_residuals_current):
-                res_init = self.equation_residuals_initial[j]
-                if res_init == 0:
-                    res_rel = res
-                else:
-                    res_rel = res / res_init
+        self.equation_residuals_current = self.residual_computer.compute(
+            self.residual_convergence.vec()
+        )
 
-                log.debug(
-                    f"Equation {j:d} "
-                    f"relative resid {res_rel:.3e} "
-                    f"absolute resid {res:.3e}"
-                )
+        for j, res in enumerate(self.equation_residuals_current):
+            res_init = self.equation_residuals_initial[j]
+            if res_init == 0:
+                res_rel = res
+            else:
+                res_rel = res / res_init
+
+            log.debug(
+                f"Equation {j:d} relative resid {res_rel:.3e} absolute resid {res:.3e}"
+            )
 
         self.rtol = cast(float, self.rtol)
         self.atol = cast(float, self.atol)
@@ -456,10 +452,6 @@ class TSPseudoSolver:
             max_time = ts.getMaxTime()
             ts.setTime(max_time)
         elif self.res_current > self.dtol * self.res_initial:
-            if hasattr(PETSc, "garbage_cleanup"):
-                self._destroy_petsc_objects()
-                ts.destroy()
-                PETSc.garbage_cleanup(comm=self.comm)
             raise _exceptions.PETScTSError(-5)
 
     def _destroy_petsc_objects(self) -> None:
@@ -476,6 +468,8 @@ class TSPseudoSolver:
 
         if self.MP_petsc is not None:
             self.MP_petsc.destroy()
+
+        self.residual_computer.destroy()
 
     def solve(self) -> fenics.Function:
         """Solves the (nonlinear) problem with pseudo time stepping.
@@ -519,14 +513,9 @@ class TSPseudoSolver:
             )
 
         self.res_initial = self.compute_nonlinear_residual(self.u.vector().vec())
-        if log.is_enabled_for(log.DEBUG):
-            self.equation_residuals_initial = np.array(
-                _utils.compute_equation_residuals(
-                    self.residual_convergence.vec(), self.space
-                )
-            )
-        else:
-            self.equation_residuals_initial = np.array([])
+        self.equation_residuals_initial = self.residual_computer.compute(
+            self.residual_convergence.vec()
+        )
         ts.setTime(0.0)
 
         ts.setMonitor(self.monitor)
@@ -548,18 +537,19 @@ class TSPseudoSolver:
         x.vector().vec().aypx(0.0, self.u.vector().vec())
         x.vector().apply("")
 
-        ts.solve(x.vector().vec())
-        converged_reason = ts.getConvergedReason()
+        try:
+            ts.solve(x.vector().vec())
+            converged_reason = ts.getConvergedReason()
+        finally:
+            self._destroy_petsc_objects()
+            ts.destroy()
+            if hasattr(PETSc, "garbage_cleanup"):
+                PETSc.garbage_cleanup(comm=self.comm)
 
         self.u.vector().vec().aypx(0.0, x.vector().vec())
         self.u.vector().apply("")
 
         log.end()
-
-        if hasattr(PETSc, "garbage_cleanup"):
-            self._destroy_petsc_objects()
-            ts.destroy()
-            PETSc.garbage_cleanup(comm=self.comm)
 
         if converged_reason < 0:
             raise _exceptions.PETScTSError(converged_reason)

--- a/cashocs/nonlinear_solvers/ts.py
+++ b/cashocs/nonlinear_solvers/ts.py
@@ -157,29 +157,37 @@ class TSPseudoSolver:
         self.assembler.keep_diagonal = True
 
         if A_tensor is not None:
-            self.A_petsc = A_tensor.mat()  # pylint: disable=invalid-name,
+            self.A_fenics = A_tensor  # pylint: disable=invalid-name
         else:
-            self.A_petsc = fenics.PETScMatrix(self.comm).mat()
+            self.A_fenics = fenics.PETScMatrix(  # pylint: disable=invalid-name
+                self.comm
+            )
+        self.A_petsc = self.A_fenics.mat()  # pylint: disable=invalid-name
 
         if b_tensor is not None:
-            self.residual_petsc = b_tensor.vec()
+            self.residual_fenics = b_tensor
         else:
-            self.residual_petsc = fenics.PETScVector(self.comm).vec()
+            self.residual_fenics = fenics.PETScVector(self.comm)
+        self.residual_petsc = self.residual_fenics.vec()
 
         self.residual_convergence = fenics.PETScVector(self.comm)
 
-        self.mass_matrix_petsc = fenics.PETScMatrix(self.comm).mat()
-        self.mass_application_petsc = fenics.Function(self.space).vector().vec()
+        self.mass_matrix_fenics = fenics.PETScMatrix(self.comm)
+        self.mass_matrix_petsc = self.mass_matrix_fenics.mat()
+        self.mass_application = fenics.Function(self.space)
+        self.mass_application_petsc = self.mass_application.vector().vec()
 
         if self.preconditioner_form is not None:
             self.assembler_pc = fenics.SystemAssembler(
                 self.preconditioner_form, self.nonlinear_form, self.bcs
             )
             self.assembler_pc.keep_diagonal = True
-            self.P_petsc = fenics.PETScMatrix(  # pylint: disable=invalid-name
+            self.P_fenics = fenics.PETScMatrix(  # pylint: disable=invalid-name
                 self.comm
-            ).mat()
+            )
+            self.P_petsc = self.P_fenics.mat()  # pylint: disable=invalid-name
         else:
+            self.P_fenics = None  # pylint: disable=invalid-name
             self.P_petsc = None
 
         self.assembler_shift: fenics.SystemAssembler | None = None
@@ -235,9 +243,10 @@ class TSPseudoSolver:
             form_list.append(mass_matrix_part)
 
         form = _utils.summation(form_list)
-        M = fenics.PETScMatrix(self.mass_matrix_petsc)  # pylint: disable=invalid-name,
         zero_form = ufl.inner(fenics.Constant(np.zeros(test.ufl_shape)), test) * dx
-        fenics.assemble_system(form, zero_form, self.bcs, A_tensor=M)
+        fenics.assemble_system(
+            form, zero_form, self.bcs, A_tensor=self.mass_matrix_fenics
+        )
 
         self.M_petsc = self.mass_matrix_petsc.copy()  # pylint: disable=invalid-name,
 
@@ -268,8 +277,7 @@ class TSPseudoSolver:
         self.u.vector().vec().aypx(0.0, u)
         self.u.vector().apply("")
 
-        f_fenics = fenics.PETScVector(f)
-        self.assembler.assemble(f_fenics, self.u.vector())
+        self.assembler.assemble(self.residual_fenics, self.u.vector())
 
         if (
             self.shift is not None
@@ -303,22 +311,17 @@ class TSPseudoSolver:
         self.u.vector().vec().aypx(0.0, u)
         self.u.vector().apply("")
 
-        J = fenics.PETScMatrix(J)  # pylint: disable=invalid-name
-        self.assembler.assemble(J)
-        J.ident_zeros()
-
-        J_petsc = fenics.as_backend_type(J).mat()  # pylint: disable=invalid-name,
-        J_petsc.scale(-1)
-        J_petsc.assemble()
+        self.assembler.assemble(self.A_fenics)
+        self.A_fenics.ident_zeros()
+        self.A_petsc.scale(-1)
+        self.A_petsc.assemble()
 
         if self.preconditioner_form is not None:
-            P = fenics.PETScMatrix(P)  # pylint: disable=invalid-name
-            self.assembler_pc.assemble(P)
-            P.ident_zeros()
+            self.assembler_pc.assemble(self.P_fenics)
+            self.P_fenics.ident_zeros()
 
-            P_petsc = fenics.as_backend_type(P).mat()  # pylint: disable=invalid-name,
-            P_petsc.scale(-1)
-            P_petsc.assemble()
+            self.P_petsc.scale(-1)
+            self.P_petsc.assemble()
 
     def assemble_i_function(
         self,
@@ -409,11 +412,12 @@ class TSPseudoSolver:
 
         """
         self.res_current = self.compute_nonlinear_residual(u)
-        self.equation_residuals_current = np.array(
-            _utils.compute_equation_residuals(
-                self.residual_convergence.vec(), self.space
+        if log.is_enabled_for(log.DEBUG):
+            self.equation_residuals_current = np.array(
+                _utils.compute_equation_residuals(
+                    self.residual_convergence.vec(), self.space
+                )
             )
-        )
 
         if self.res_initial == 0:
             relative_residual = self.res_current
@@ -430,16 +434,19 @@ class TSPseudoSolver:
         if self.comm.rank == 0 and self.has_monitor_output:
             print(monitor_str, flush=True)
 
-        for j, res in enumerate(self.equation_residuals_current):
-            res_init = self.equation_residuals_initial[j]
-            if res_init == 0:
-                res_rel = res
-            else:
-                res_rel = res / res_init
+        if log.is_enabled_for(log.DEBUG):
+            for j, res in enumerate(self.equation_residuals_current):
+                res_init = self.equation_residuals_initial[j]
+                if res_init == 0:
+                    res_rel = res
+                else:
+                    res_rel = res / res_init
 
-            log.debug(
-                f"Equation {j:d} relative resid {res_rel:.3e} absolute resid {res:.3e}"
-            )
+                log.debug(
+                    f"Equation {j:d} "
+                    f"relative resid {res_rel:.3e} "
+                    f"absolute resid {res:.3e}"
+                )
 
         self.rtol = cast(float, self.rtol)
         self.atol = cast(float, self.atol)
@@ -489,7 +496,7 @@ class TSPseudoSolver:
         ksp = ts.getSNES().getKSP()
         _utils.linalg.setup_fieldsplit_preconditioner(self.u, ksp, self.petsc_options)
 
-        if fenics.PETScMatrix(self.A_petsc).empty():
+        if self.A_fenics.empty():
             self.assemble_i_function(
                 ts,
                 0.0,
@@ -512,11 +519,14 @@ class TSPseudoSolver:
             )
 
         self.res_initial = self.compute_nonlinear_residual(self.u.vector().vec())
-        self.equation_residuals_initial = np.array(
-            _utils.compute_equation_residuals(
-                self.residual_convergence.vec(), self.space
+        if log.is_enabled_for(log.DEBUG):
+            self.equation_residuals_initial = np.array(
+                _utils.compute_equation_residuals(
+                    self.residual_convergence.vec(), self.space
+                )
             )
-        )
+        else:
+            self.equation_residuals_initial = np.array([])
         ts.setTime(0.0)
 
         ts.setMonitor(self.monitor)

--- a/demos/undocumented/shape_optimization/python_pc/python_pc.py
+++ b/demos/undocumented/shape_optimization/python_pc/python_pc.py
@@ -84,16 +84,18 @@ class MyLinearSolver(cashocs._utils.linalg.LinearSolver):
         if atol is not None:
             ksp.atol = atol
 
-        ksp.solve(b, x)
+        try:
+            ksp.solve(b, x)
+            converged_reason = ksp.getConvergedReason()
+        finally:
+            ksp.destroy()
+            if hasattr(PETSc, "garbage_cleanup"):
+                PETSc.garbage_cleanup(comm=self.comm)
 
-        if ksp.getConvergedReason() < 0:
+        if converged_reason < 0:
             raise Exception(
                 f"PETSc KSP did not converge. Reason: {ksp.getConvergedReason()}"
             )
-
-        if hasattr(PETSc, "garbage_cleanup"):
-            ksp.destroy()
-            PETSc.garbage_cleanup(comm=self.comm)
 
         if fun is not None:
             fun.vector().apply("")


### PR DESCRIPTION
This PR fixes a memory leak introduced with the per-equation residual computation. 
It also improves the way PETSc objects are cleaned up, so that memory leaks may hopefully not occur as often in the future.
It also tries to reduce the wrappers to `fenics.PETScMatrix` and `fenics.PETScVector` where possible.