### PR TITLE
Add groups for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,17 +9,40 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "sunday"
       time: "03:00"
       timezone: Europe/Berlin
     assignees:
       - "sblauth"
+    groups:
+      core-workflow:
+        patterns:
+          - "actions/*"
+      conda:
+        patterns:
+          - "conda-incubator/*"
+      docker:
+        patterns:
+          - "docker/*"
+      security-scanning:
+        patterns:
+          - "github/codeql-action"
+          - "github/ossar-action"
+          - "ossf/*"
+      coverage:
+        patterns:
+          - "py-cov-action/*"
+      releases:
+        patterns:
+          - "nowsprinting/*"
+          - "softprops/*"
+          - "pypa/*"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "sunday"
       time: "03:00"
       timezone: Europe/Berlin
     allow:


### PR DESCRIPTION
This PR adds groups to dependabot, so that less PRs are created and dependencies, which belong together, are updated jointly. This fixes an issue with the CodeQL action updates, which now should work again.
Also changes the time for dependabot updates to sunday instead of monday.