### PR TITLE
Add a constant step size "line search" to cashocs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,13 @@ of the maintenance releases, please take a look at
 2.11.0 (in development)
 -----------------------
 
+* Add :py:class:`BasicLineSearch`, which is a fixed stepsize line search. 
 
+* New configuration file parameters:
+
+  * Section LineSearch
+
+    * :ini:`method` now also supports the key :ini:`method = basic` for the BasicLineSearch
 
 2.10.0 (July 14, 2026)
 ----------------------

--- a/cashocs/_optimization/line_search/__init__.py
+++ b/cashocs/_optimization/line_search/__init__.py
@@ -18,6 +18,7 @@
 """Line search algorithms."""
 
 from cashocs._optimization.line_search.armijo_line_search import ArmijoLineSearch
+from cashocs._optimization.line_search.basic_line_search import BasicLineSearch
 from cashocs._optimization.line_search.line_search import LineSearch
 from cashocs._optimization.line_search.polynomial_line_search import (
     PolynomialLineSearch,
@@ -25,6 +26,7 @@ from cashocs._optimization.line_search.polynomial_line_search import (
 
 __all__ = [
     "ArmijoLineSearch",
+    "BasicLineSearch",
     "LineSearch",
     "PolynomialLineSearch",
 ]

--- a/cashocs/_optimization/line_search/basic_line_search.py
+++ b/cashocs/_optimization/line_search/basic_line_search.py
@@ -1,0 +1,154 @@
+# Copyright (C) 2020-2026 Fraunhofer ITWM and Sebastian Blauth
+#
+# This file is part of cashocs.
+#
+# cashocs is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cashocs is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with cashocs.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Basic line search algorithm with constant step size."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import fenics
+
+from cashocs import _exceptions
+from cashocs import log
+from cashocs._optimization.line_search import line_search
+
+if TYPE_CHECKING:
+    import numpy as np
+    from scipy import sparse
+
+    from cashocs import _typing
+    from cashocs._database import database
+    from cashocs._optimization import optimization_algorithms
+
+
+class BasicLineSearch(line_search.LineSearch):
+    """Implementation of the basic line search procedure with constant step size."""
+
+    def __init__(
+        self,
+        db: database.Database,
+        optimization_problem: _typing.OptimizationProblem,
+    ) -> None:
+        """Initializes self.
+
+        Args:
+            db: The database of the problem.
+            optimization_problem: The corresponding optimization problem.
+
+        """
+        super().__init__(db, optimization_problem)
+
+        self.constant_stepsize = self.stepsize
+
+    def search(
+        self,
+        solver: optimization_algorithms.OptimizationAlgorithm,
+        search_direction: list[fenics.Function],
+        has_curvature_info: bool,
+        active_idx: np.ndarray | None = None,
+        constraint_gradient: sparse.csr_matrix | None = None,
+        dropped_idx: np.ndarray | None = None,
+    ) -> tuple[fenics.Function | None, bool]:
+        """Performs the line search.
+
+        Args:
+            solver: The optimization algorithm.
+            search_direction: The current search direction.
+            has_curvature_info: A flag, which indicates whether the direction is
+                (presumably) scaled.
+            active_idx: The list of active indices of the working set. Only needed
+                for shape optimization with mesh quality constraints. Default is `None`.
+            constraint_gradient: The gradient of the constraints for the mesh quality.
+                Only needed for shape optimization with mesh quality constraints.
+                Default is `None`.
+            dropped_idx: The list of indicies for dropped constraints. Only needed
+                for shape optimization with mesh quality constraints. Default is `None`.
+
+        Returns:
+            A tuple (defo, is_remeshed), where defo is accepted deformation / update
+            or None, in case the update was not successful and is_remeshed is a boolean
+            indicating whether a remeshing has been performed in the line search.
+
+        """
+        self.stepsize = self.constant_stepsize
+        is_remeshed = False
+
+        log.begin("Basic line search.", level=log.DEBUG)
+        while True:
+            self.stepsize = (
+                self.optimization_variable_abstractions.update_optimization_variables(
+                    search_direction,
+                    self.stepsize,
+                    self.beta_armijo,
+                    active_idx,
+                    constraint_gradient,
+                    dropped_idx,
+                )
+            )
+
+            objective_step = self._compute_objective_at_new_iterate()
+            if objective_step is not None:
+                log.debug(
+                    f"Stepsize: {self.stepsize:.3e}  -"
+                    f"  Tentative cost function value: {objective_step:.3e}"
+                )
+                if self.optimization_variable_abstractions.requires_remeshing():
+                    log.debug(
+                        "The mesh quality was sufficient for accepting the step, "
+                        "but the mesh cannot be used anymore for computing a gradient."
+                        "Performing a remeshing operation."
+                    )
+                    is_remeshed = (
+                        self.optimization_variable_abstractions.mesh_handler.remesh(
+                            solver
+                        )
+                    )
+                break
+            else:
+                log.debug(
+                    f"Stepsize: {self.stepsize:.3e} - Objective could not be evaluated."
+                )
+                self.stepsize /= self.beta_armijo
+                self.optimization_variable_abstractions.revert_variable_update()
+
+        log.end()
+        solver.stepsize = self.stepsize
+
+        if self.problem_type == "shape":
+            return (self.optimization_variable_abstractions.deformation, is_remeshed)
+        else:
+            return (None, False)
+
+    def _compute_objective_at_new_iterate(self) -> float | None:
+        """Computes the objective value for the new (trial) iterate.
+
+        Returns:
+            The value of the cost functional at the new iterate.
+
+        """
+        self.state_problem.has_solution = False
+        try:
+            objective_step = self.cost_functional.evaluate()
+        except (_exceptions.PETScError, _exceptions.NotConvergedError) as error:
+            if self.config.getboolean("LineSearch", "fail_if_not_converged"):
+                raise error
+            else:
+                objective_step = None
+                self.state_problem.revert_to_checkpoint()
+
+        return objective_step

--- a/cashocs/_optimization/optimal_control/optimal_control_problem.py
+++ b/cashocs/_optimization/optimal_control/optimal_control_problem.py
@@ -316,6 +316,8 @@ class OptimalControlProblem(optimization_problem.OptimizationProblem):
             line_search: ls.LineSearch = ls.ArmijoLineSearch(self.db, self)
         elif line_search_type == "polynomial":
             line_search = ls.PolynomialLineSearch(self.db, self)
+        elif line_search_type == "basic":
+            line_search = ls.BasicLineSearch(self.db, self)
         else:
             raise _exceptions.CashocsException("This code cannot be reached.")
 

--- a/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
+++ b/cashocs/_optimization/shape_optimization/shape_optimization_problem.py
@@ -430,6 +430,8 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
             line_search: ls.LineSearch = ls.ArmijoLineSearch(self.db, self)
         elif line_search_type == "polynomial":
             line_search = ls.PolynomialLineSearch(self.db, self)
+        elif line_search_type == "basic":
+            line_search = ls.BasicLineSearch(self.db, self)
         else:
             raise _exceptions.CashocsException("This code cannot be reached.")
 
@@ -451,7 +453,7 @@ class ShapeOptimizationProblem(optimization_problem.OptimizationProblem):
             )
         elif self.algorithm.casefold() == "none":
             raise _exceptions.InputError(
-                "cashocs.OptimalControlProblem.solve",
+                "cashocs.ShapeOptimizationProblem.solve",
                 "algorithm",
                 "You did not specify a solution algorithm in your config file. "
                 "You have to specify one in the solve "

--- a/cashocs/_optimization/topology_optimization/topology_optimization_problem.py
+++ b/cashocs/_optimization/topology_optimization/topology_optimization_problem.py
@@ -330,6 +330,8 @@ class TopologyOptimizationProblem(optimization_problem.OptimizationProblem):
             line_search: ls.LineSearch = ls.ArmijoLineSearch(self.db, self)
         elif line_search_type == "polynomial":
             line_search = ls.PolynomialLineSearch(self.db, self)
+        elif line_search_type == "basic":
+            line_search = ls.BasicLineSearch(self.db, self)
         else:
             raise _exceptions.CashocsException("This code cannot be reached.")
 

--- a/cashocs/geometry/mesh_handler.py
+++ b/cashocs/geometry/mesh_handler.py
@@ -492,6 +492,8 @@ class _MeshHandler:
             )
         elif line_search_type == "polynomial":
             line_search = ls.PolynomialLineSearch(self.db, solver.optimization_problem)
+        elif line_search_type == "basic":
+            line_search = ls.BasicLineSearch(self.db, solver.optimization_problem)
         else:
             raise _exceptions.CashocsException("This code cannot be reached.")
 

--- a/cashocs/io/config.py
+++ b/cashocs/io/config.py
@@ -207,7 +207,7 @@ class Config(ConfigParser):
             "LineSearch": {
                 "method": {
                     "type": "str",
-                    "possible_options": ["armijo", "polynomial"],
+                    "possible_options": ["armijo", "polynomial", "basic"],
                 },
                 "initial_stepsize": {
                     "type": "float",

--- a/docs/source/user/demos/optimal_control/doc_config.rst
+++ b/docs/source/user/demos/optimal_control/doc_config.rst
@@ -109,7 +109,7 @@ LineSearch
     * - Parameter = Default value
       - Description and remarks
     * - :ini:`method = armio`
-      - :ini:`method = armijo` is a simple backtracking line search, whereas :ini:`method = polynomial` uses polynomial models to compute trial stepsizes.
+      - :ini:`method = armijo` is a simple backtracking line search, :ini:`method = polynomial` uses polynomial models, and :ini:`method = basic` uses a fixed step size.
     * - :ini:`initial_stepsize = 1.0`
       - initial stepsize for the first iteration in the Armijo rule
     * - :ini:`epsilon_armijo = 1e-4`
@@ -551,7 +551,7 @@ In this section, parameters regarding the line search can be specified. The type
 
     method = armijo
     
-Possible options are :ini:`method = armijo`, which performs a simple backtracking line search based on the armijo rule with fixed steps (think of halving the stepsize in each iteration), and :ini:`method = polynomial`, which uses polynomial models of the cost functional restricted to the line to generate "better" guesses for the stepsize. The default is :ini:`method = armijo`. 
+Possible options are :ini:`method = armijo`, which performs a simple backtracking line search based on the armijo rule with fixed steps (think of halving the stepsize in each iteration), and :ini:`method = polynomial`, which uses polynomial models of the cost functional restricted to the line to generate "better" guesses for the stepsize. A fixed step size line search can be used with :ini:`method = basic`. The default is :ini:`method = armijo`. 
 
 The next parameter, :ini:`polynomial_model`, specifies, which type of polynomials are used to generate new trial stepsizes. It is set via 
 

--- a/docs/source/user/demos/shape_optimization/doc_config.rst
+++ b/docs/source/user/demos/shape_optimization/doc_config.rst
@@ -141,7 +141,7 @@ LineSearch
     * - Parameter = Default value
       - Description and remarks
     * - :ini:`method = armijo`
-      - :ini:`method = armijo` is a simple backtracking line search, whereas :ini:`method = polynomial` uses polynomial models to compute trial stepsizes.
+      - :ini:`method = armijo` is a simple backtracking line search, :ini:`method = polynomial` uses polynomial models, and :ini:`method = basic` uses a fixed step size.
     * - :ini:`initial_stepsize = 1.0`
       - initial stepsize for the first iteration in the Armijo rule
     * - :ini:`epsilon_armijo = 1e-4`
@@ -724,7 +724,7 @@ In this section, parameters regarding the line search can be specified. The type
 
     method = armijo
     
-Possible options are :ini:`method = armijo`, which performs a simple backtracking line search based on the armijo rule with fixed steps (think of halving the stepsize in each iteration), and :ini:`method = polynomial`, which uses polynomial models of the cost functional restricted to the line to generate "better" guesses for the stepsize. The default is :ini:`method = armijo`. 
+Possible options are :ini:`method = armijo`, which performs a simple backtracking line search based on the armijo rule with fixed steps (think of halving the stepsize in each iteration), and :ini:`method = polynomial`, which uses polynomial models of the cost functional restricted to the line to generate "better" guesses for the stepsize. A fixed step size line search can be used with :ini:`method = basic`. The default is :ini:`method = armijo`. 
 
 The next parameter, :ini:`polynomial_model`, specifies, which type of polynomials are used to generate new trial stepsizes. It is set via
 

--- a/tests/test_optimal_control.py
+++ b/tests/test_optimal_control.py
@@ -814,3 +814,15 @@ def test_adjoint_linearizations(geometry, config_ocp):
     )
     # ocp.compute_adjoint_variables()
     ocp.solve(rtol=1e-2, max_iter=50)
+
+
+@pytest.mark.parametrize(
+    "algorithm, step, iterations",
+    [("gd", 5e2, 71), ("ncg", 5e2, 76), ("bfgs", 0.1, 43)],
+)
+def test_basic_stepsize(ocp, algorithm, step, iterations):
+    ocp.config.set("LineSearch", "method", "basic")
+    ocp.config.set("LineSearch", "initial_stepsize", str(step))
+
+    ocp.solve(algorithm=algorithm, rtol=1e-2, atol=0.0, max_iter=iterations)
+    assert ocp.solver.relative_norm <= ocp.solver.rtol

--- a/tests/test_shape_optimization.py
+++ b/tests/test_shape_optimization.py
@@ -1138,3 +1138,20 @@ def test_shape_volume_fix():
     assert assemble(Constant(1.0) * dx("bottom_right")) == pytest.approx(0.25)
 
     assert sop.solver.relative_norm <= sop.solver.rtol
+
+
+@pytest.mark.parametrize(
+    "algorithm, step, iterations",
+    [("gd", 0.25, 45), ("ncg", 0.25, 12), ("bfgs", 0.1, 33)],
+)
+def test_basic_stepsize(algorithm, step, iterations):
+    config = cashocs.load_config(dir_path + "/config_sop.ini")
+
+    config.set("LineSearch", "method", "basic")
+    config.set("LineSearch", "initial_stepsize", str(step))
+
+    mesh.coordinates()[:, :] = initial_coordinates
+    mesh.bounding_box_tree().build(mesh)
+    sop = cashocs.ShapeOptimizationProblem(e, bcs, J, u, p, boundaries, config)
+    sop.solve(algorithm=algorithm, rtol=1e-2, atol=0.0, max_iter=iterations)
+    assert sop.solver.relative_norm <= sop.solver.rtol


### PR DESCRIPTION
This PR implements the so-called `BasicLineSearch`, which uses a fixed step size for the optimization.

Closes #959 