### PR TITLE
Disable auto rebasing of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
       timezone: Europe/Berlin
     assignees:
       - "sblauth"
+    rebase-strategy: "disabled"
     groups:
       core-workflow:
         patterns:
@@ -49,3 +50,4 @@ updates:
       - dependency-type: "all"
     assignees:
       - "sblauth"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
This PR disables the automatic rebasing of dependabot PRs. This is done to save CI resources.