### PR TITLE
FIX: Use only locally owned dg zero indices when computing material parameters

### DIFF
--- a/cashocs/_utils/forms.py
+++ b/cashocs/_utils/forms.py
@@ -358,6 +358,7 @@ def create_material_parameter(
         indicator_function = fenics.Function(dg0_space)
         subdomain_ids = _get_subdomain_ids_from_tag(subdomain_tag, mesh.physical_groups)
         dg0_idx = np.flatnonzero(np.isin(mesh.subdomains.array(), subdomain_ids))
+        dg0_idx = dg0_idx[dg0_idx < indicator_function.vector().local_size()]
 
         indicator_function.vector()[dg0_idx] = 1.0
         indicator_function.vector().apply("")


### PR DESCRIPTION
With the changes in #968, subdomains are updated to include correct values for ghosted entities. This leads to an error when trying to create material parameters, where the corresponding DG0 function wants to set values to ghosted entries.
This is fixed with this PR.