### PR TITLE
Add a termination guard to the basic line search

### DIFF
--- a/cashocs/_optimization/line_search/basic_line_search.py
+++ b/cashocs/_optimization/line_search/basic_line_search.py
@@ -22,13 +22,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import fenics
+import numpy as np
 
 from cashocs import _exceptions
 from cashocs import log
 from cashocs._optimization.line_search import line_search
 
 if TYPE_CHECKING:
-    import numpy as np
     from scipy import sparse
 
     from cashocs import _typing
@@ -54,6 +54,42 @@ class BasicLineSearch(line_search.LineSearch):
         super().__init__(db, optimization_problem)
 
         self.constant_stepsize = self.stepsize
+
+    def _check_for_nonconvergence(
+        self, solver: optimization_algorithms.OptimizationAlgorithm
+    ) -> bool:
+        """Checks, whether the line search failed to converge.
+
+        Returns True (i.e. requests termination of the line search) when either
+        criterion is satisfied:
+
+        * The optimization algorithm reached its iteration limit
+          (``solver.iteration >= solver.max_iter``).
+        * The step size became too small for the optimization variables to change
+          meaningfully (``stepsize * search_direction_inf <= 1e-9``). In this case
+          the line search is flagged as broken via
+          ``solver.line_search_broken = True``.
+
+        Args:
+            solver: The optimization algorithm, which uses the line search.
+
+        Returns:
+            True if a termination criterion is satisfied, False otherwise.
+
+        """
+        if solver.iteration >= solver.max_iter:
+            return True
+
+        if self.stepsize * self.search_direction_inf <= 1e-9:
+            log.error(
+                "The stepsize is too small. "
+                "The changes in the optimization variables are too small for the "
+                "current search direction."
+            )
+            solver.line_search_broken = True
+            return True
+
+        return False
 
     def search(
         self,
@@ -86,10 +122,18 @@ class BasicLineSearch(line_search.LineSearch):
 
         """
         self.stepsize = self.constant_stepsize
+        self.search_direction_inf = np.max(
+            [
+                search_direction[i].vector().norm("linf")
+                for i in range(len(search_direction))
+            ]
+        )
         is_remeshed = False
 
         log.begin("Basic line search.", level=log.DEBUG)
         while True:
+            if self._check_for_nonconvergence(solver):
+                return (None, False)
             self.stepsize = (
                 self.optimization_variable_abstractions.update_optimization_variables(
                     search_direction,

--- a/tests/test_optimal_control.py
+++ b/tests/test_optimal_control.py
@@ -826,3 +826,22 @@ def test_basic_stepsize(ocp, algorithm, step, iterations):
 
     ocp.solve(algorithm=algorithm, rtol=1e-2, atol=0.0, max_iter=iterations)
     assert ocp.solver.relative_norm <= ocp.solver.rtol
+
+
+def test_basic_line_search_terminates_on_failure(monkeypatch, ocp):
+    """BasicLineSearch must terminate when trial steps persistently fail.
+
+    Regression test: without a termination guard, a persistently failing
+    objective (e.g. a diverged state solve with ``fail_if_not_converged = False``)
+    drove the stepsize to zero and looped forever. The search must instead give
+    up gracefully, like the Armijo and polynomial searches.
+    """
+    from cashocs._optimization.line_search.basic_line_search import BasicLineSearch
+
+    ocp.config.set("LineSearch", "method", "basic")
+    monkeypatch.setattr(
+        BasicLineSearch, "_compute_objective_at_new_iterate", lambda self: None
+    )
+
+    with pytest.raises(NotConvergedError):
+        ocp.solve(algorithm="gd", rtol=1e-2, atol=0.0, max_iter=1)


### PR DESCRIPTION
BasicLineSearch is the only line search without the `_check_for_nonconvergence` guard that ArmijoLineSearch and PolynomialLineSearch already have. 

This adds the same guard: when the step size becomes too small for the optimization variables to change, the line search stops and is flagged as broken, so the optimization terminates with a `NotConvergedError` instead of continuing to shrink the step size without a lower bound.
- mirrors the existing `_check_for_nonconvergence` in the sibling line searches
- default (Armijo) behavior is unchanged; full test suite passes (224 tests)
- adds a regression test `test_basic_line_search_terminates_on_failure`